### PR TITLE
docs: expand backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Monorepo containing a React client and a FastAPI backend for an LLM-powered data
 
 - `client/` – React front-end (empty placeholder).
 - `server/` – FastAPI application exposing the chatbot API.
+  - `api/` – route declarations grouped by resource.
+  - `schemas/` – Pydantic models for requests and responses.
+  - `services/` – business logic and database access helpers.
+  - `main.py` – creates the FastAPI app and wires the routes.
 
 ## Running the backend
 
@@ -24,7 +28,24 @@ appropriate charts via the OpenAI API.
 
 ### API
 
-The `/query` endpoint expects a JSON payload:
+The backend exposes the following REST endpoints:
+
+#### Users
+- `POST /users` – create a new user.
+- `PUT /users/{user_id}` – update an existing user.
+
+#### Database connections
+- `POST /db-connections` – register a database connection for a user.
+- `PUT /db-connections/{db_connection_id}` – update connection settings.
+- `POST /db-connections/{db_connection_id}/disable` – disable a connection.
+- `POST /db-connections/{db_connection_id}/enable` – re-enable a connection.
+
+#### Conversations
+- `POST /conversations` – start a new conversation tied to a database connection.
+- `POST /conversations/{conversation_id}/query` – send a prompt in the context of a conversation.
+
+#### Ad-hoc query
+The `POST /query` endpoint processes a one-off prompt without conversation state and expects a JSON payload:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- document server directory structure
- list REST endpoints for users, database connections, conversations, and ad-hoc queries

## Testing
- `cd server && uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d63666b1083238c7268a5fe01ecc5