### PR TITLE
feat: add conversation retrieval and cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ Environment variables:
 - `JWT_SECRET` – secret used to sign JWTs (`change-me` default)
 - `JWT_EXP_SECONDS` – token lifetime in seconds (defaults to one day)
 
+## API overview
+
+All routes are served under the `/api/v1` prefix and require a valid
+JWT cookie unless noted.
+
+### Users
+- `POST /users` – register a new user
+- `POST /users/login` – authenticate and receive the JWT cookie
+
+### Database connections
+- `GET /db-connections` – list connections for the current user
+- `POST /db-connections` – create a new connection
+- `PUT /db-connections/{id}` – update a connection
+- `POST /db-connections/{id}/enable` – enable a connection
+- `POST /db-connections/{id}/disable` – disable a connection
+
+### Conversations
+- `GET /conversations` – list conversations for the current user
+- `GET /conversations/{id}` – fetch a conversation with its messages
+- `POST /conversations` – create a conversation
+- `POST /conversations/{id}/query` – send a prompt and receive chart data
+
 ## Running the frontend
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # llm-data-analyst
 
-Monorepo containing a React client and a FastAPI backend for an LLM-powered data analysis chatbot.
+Full‑stack demo of an LLM‑powered data analysis assistant. The repository contains a
+React + Vite front end and a FastAPI backend.
+
+## Features
+
+- User registration and login with JWT stored in HTTP‑only cookies
+- Manage and enable/disable database connections
+- Create conversations and retrieve full message history
+- Toggleable sidebar for switching conversations and configuring connections
 
 ## Structure
 
-- `client/` – React front-end (empty placeholder).
-- `server/` – FastAPI application exposing the chatbot API.
+- `client/` – React front‑end
+- `server/` – FastAPI application exposing the chatbot API
 
 ## Running the backend
 
@@ -18,29 +26,22 @@ uv sync
 uv run uvicorn server.main:app --reload
 ```
 
-Set the `LLM_API_KEY` environment variable before starting the server. The backend uses
-LangChain's SQLAgent to translate natural language prompts into SQL queries and select
-appropriate charts via the OpenAI API.
+Environment variables:
 
-### API
+- `LLM_API_KEY` – API key for the LLM provider
+- `JWT_SECRET` – secret used to sign JWTs (`change-me` default)
+- `JWT_EXP_SECONDS` – token lifetime in seconds (defaults to one day)
 
-The `/query` endpoint expects a JSON payload:
+## Running the frontend
 
-```json
-{
-  "prompt": "total sales by month",
-  "model_name": "gpt-4.1-mini",
-  "db_connection": {
-    "db_name": "postgres",
-    "user": "postgres",
-    "password": "postgres",
-    "host": "localhost",
-    "port": 5432
-  },
-  "available_charts": ["bar", "line", "pie"]
-}
+```bash
+cd client
+npm install
+npm run dev
 ```
 
-`extract_data` returns a raw JSON array of objects from the database. `choose_charts` uses
-the natural-language request, the available chart types and that JSON data to select chart
-types and shape the data for each chart in the response.
+The client expects the API at `http://localhost:8000`; override with
+`VITE_API_BASE_URL` in a `.env` file if needed.
+
+On first launch, register an account on the login page. After logging in, create a
+database connection from the dropdown to start a conversation and run queries.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-scroll-area": "^1.2.9",
+        "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-separator": "^1.1.7",
         "@tailwindcss/vite": "^4.1.11",
         "class-variance-authority": "^0.7.1",
@@ -619,6 +621,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
+      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -782,6 +822,29 @@
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
@@ -793,6 +856,32 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -839,6 +928,72 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -850,6 +1005,153 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -932,6 +1234,55 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
@@ -988,6 +1339,61 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-is-hydrated": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
@@ -1020,6 +1426,86 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.30",
@@ -2157,6 +2643,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2327,6 +2825,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -2710,6 +3214,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/glob-parent": {
@@ -3471,6 +3984,75 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3742,6 +4324,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tw-animate-css": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.6.tgz",
@@ -3818,6 +4406,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-separator": "^1.1.7",
     "@tailwindcss/vite": "^4.1.11",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,179 +1,27 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { cn } from '@/lib/utils'
-import { Input } from '@/components/ui/input'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import { ScrollArea } from '@/components/ui/scroll-area'
-import { Separator } from '@/components/ui/separator'
-import { Send, Bot, User } from 'lucide-react'
-import { queryApi, type QueryResponse, type QueryRequest } from '@/lib/api'
+import { useState } from 'react'
+import Login from '@/pages/Login'
+import Chat from '@/pages/Chat'
 
-type Message = {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  pending?: boolean
-}
-
-function ChatBubble({ message }: { message: Message }) {
-  const isUser = message.role === 'user'
-  return (
-    <div className={cn('flex w-full gap-3', isUser ? 'justify-end' : 'justify-start')}>
-      {!isUser && (
-        <Avatar className="h-8 w-8">
-          <AvatarFallback>
-            <Bot className="h-4 w-4" />
-          </AvatarFallback>
-        </Avatar>
-      )}
-      <div
-        className={cn(
-          'max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm',
-          isUser
-            ? 'bg-primary text-primary-foreground rounded-br-sm'
-            : 'bg-secondary text-secondary-foreground rounded-bl-sm'
-        )}
-      >
-        {message.pending ? (
-          <span className="inline-flex items-center gap-1 opacity-70">
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.2s]"></span>
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.1s]"></span>
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current"></span>
-          </span>
-        ) : (
-          <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
-        )}
-      </div>
-      {isUser && (
-        <Avatar className="h-8 w-8">
-          <AvatarFallback>
-            <User className="h-4 w-4" />
-          </AvatarFallback>
-        </Avatar>
-      )}
-    </div>
-  )
-}
+type User = { id: string; username: string }
 
 export default function App() {
-  const [messages, setMessages] = useState<Message[]>([])
-  const [input, setInput] = useState('')
-  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const [user, setUser] = useState<User | null>(() => {
+    const id = localStorage.getItem('user_id')
+    const username = localStorage.getItem('username')
+    return id && username ? { id, username } : null
+  })
 
-  // Demo defaults; adjust via env/inputs or hook to real settings UI.
-  const defaults = useMemo<Pick<QueryRequest, 'db_connection' | 'available_charts' | 'model_name'>>(
-    () => ({
-      db_connection: {
-        db_name: 'example_db',
-        user: 'example_user',
-        password: 'example_password',
-        host: 'localhost',
-        port: 5432,
-      },
-      available_charts: ['bar', 'line', 'pie'],
-      model_name: 'gpt-4o-mini',
-    }),
-    []
-  )
-
-  useEffect(() => {
-    // Auto-scroll to bottom on new messages
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
-  }, [messages])
-
-  const handleSend = useCallback(async () => {
-    const trimmed = input.trim()
-    if (!trimmed) return
-
-    const id = crypto.randomUUID()
-    const loadingId = crypto.randomUUID()
-
-    setMessages((prev) => [
-      ...prev,
-      { id, role: 'user', content: trimmed },
-      { id: loadingId, role: 'assistant', content: '', pending: true },
-    ])
-    setInput('')
-
-    try {
-      const res: QueryResponse = await queryApi({
-        prompt: trimmed,
-        ...defaults,
-      })
-
-      // Render a compact summary of the response for the chat bubble.
-      const assistantText = res.charts
-        .map((c, i) => {
-          const r = c.reasoning ? `\nReasoning: ${c.reasoning}` : ''
-          return `Chart #${i + 1}: ${c.chart_type}${r}\nData: ${JSON.stringify(c.data, null, 2)}`
-        })
-        .join('\n\n') || 'No charts returned.'
-
-      setMessages((prev) =>
-        prev.map((m) => (m.id === loadingId ? { ...m, content: assistantText, pending: false } : m))
-      )
-    } catch (err: any) {
-      const errorText = err?.message ? `Error: ${err.message}` : 'Unexpected error.'
-      setMessages((prev) =>
-        prev.map((m) => (m.id === loadingId ? { ...m, content: errorText, pending: false } : m))
-      )
-    }
-  }, [input, defaults])
-
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      handleSend()
-    }
+  if (!user) {
+    return (
+      <Login
+        onLogin={(u) => {
+          setUser(u)
+          localStorage.setItem('user_id', u.id)
+          localStorage.setItem('username', u.username)
+        }}
+      />
+    )
   }
 
-  return (
-    <div className="flex h-dvh w-full items-stretch">
-      <div className="flex w-full flex-col">
-        <header className="border-b px-4 py-2">
-          <div className="mx-auto flex max-w-3xl items-center justify-between">
-            <div className="font-semibold">LLM Data Analyst</div>
-          </div>
-        </header>
-
-        <main className="flex min-h-0 flex-1">
-          <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col">
-            <ScrollArea className="flex-1 px-4 py-4">
-              <div className="flex flex-col gap-3">
-                {messages.length === 0 && (
-                  <div className="text-center text-sm text-muted-foreground">
-                    Ask a question about your data to get started.
-                  </div>
-                )}
-                {messages.map((m) => (
-                  <ChatBubble key={m.id} message={m} />
-                ))}
-                <div ref={bottomRef} />
-              </div>
-            </ScrollArea>
-            <Separator />
-            <div className="px-4 pb-4 pt-2">
-              <div className="relative mx-auto flex max-w-3xl items-center gap-2">
-                <Input
-                  placeholder="Send a message..."
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  onKeyDown={onKeyDown}
-                  className="pr-10"
-                  aria-label="Chat input"
-                />
-                <button
-                  type="button"
-                  onClick={handleSend}
-                  className="absolute right-2 inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
-                  aria-label="Send"
-                >
-                  <Send className="h-4 w-4" />
-                </button>
-              </div>
-            </div>
-          </div>
-        </main>
-      </div>
-    </div>
-  )
+  return <Chat user={user} />
 }

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable react-refresh/only-export-components */
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+import { type ButtonHTMLAttributes, forwardRef } from "react"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3",
+        lg: "h-10 rounded-md px-8",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-1">
+        <X className="h-4 w-4" />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+}

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -1,0 +1,74 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+const SelectGroup = SelectPrimitive.Group
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronsUpDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Content
+    ref={ref}
+    className={cn(
+      "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+      position === "popper" && "translate-y-1",
+      className
+    )}
+    position={position}
+    {...props}
+  >
+    <SelectPrimitive.Viewport className="p-1">
+      {children}
+    </SelectPrimitive.Viewport>
+  </SelectPrimitive.Content>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectItem }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -30,6 +30,7 @@ export async function queryApi(body: QueryRequest): Promise<QueryResponse> {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    credentials: 'include',
   })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
@@ -38,3 +39,117 @@ export async function queryApi(body: QueryRequest): Promise<QueryResponse> {
   return (await res.json()) as QueryResponse
 }
 
+export async function loginApi(body: { username: string; password: string }) {
+  const res = await fetch(`${API_BASE}/users/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Login failed')
+  return (await res.json()) as { user_id: string; username: string }
+}
+
+export async function registerApi(body: { name: string; email: string; password: string }) {
+  const res = await fetch(`${API_BASE}/users`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error('Register failed')
+  return (await res.json()) as { user_id: string }
+}
+
+export async function listDbConnections() {
+  const res = await fetch(`${API_BASE}/db-connections`, {
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to list connections')
+  return (await res.json()) as { id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }[]
+}
+
+export async function createDbConnection(body: DBConnection & { user_id: string }) {
+  const res = await fetch(`${API_BASE}/db-connections`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to create connection')
+  return (await res.json()) as { db_connection_id: string }
+}
+
+export async function updateDbConnection(id: string, body: DBConnection & { user_id: string }) {
+  const res = await fetch(`${API_BASE}/db-connections/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to update connection')
+  return (await res.json()) as { status: string }
+}
+
+export async function enableDbConnection(id: string, user_id: string) {
+  const res = await fetch(`${API_BASE}/db-connections/${id}/enable`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id }),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to enable connection')
+  return (await res.json()) as { status: string }
+}
+
+export async function disableDbConnection(id: string, user_id: string) {
+  const res = await fetch(`${API_BASE}/db-connections/${id}/disable`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id }),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to disable connection')
+  return (await res.json()) as { status: string }
+}
+
+export async function listConversations() {
+  const res = await fetch(`${API_BASE}/conversations`, {
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to list conversations')
+  return (await res.json()) as { id: string; title: string | null }[]
+}
+
+export async function getConversation(id: string) {
+  const res = await fetch(`${API_BASE}/conversations/${id}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to get conversation')
+  return (await res.json()) as {
+    id: string
+    title: string | null
+    messages: { id: string; role: string; content: unknown }[]
+  }
+}
+
+export async function createConversation(body: { user_id: string; db_connection_id: string; title?: string; model?: string }) {
+  const res = await fetch(`${API_BASE}/conversations`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Failed to create conversation')
+  return (await res.json()) as { conversation_id: string }
+}
+
+export async function conversationQuery(conversation_id: string, body: { prompt: string; available_charts: string[]; model_name: string }) {
+  const res = await fetch(`${API_BASE}/conversations/${conversation_id}/query`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error('Query failed')
+  return (await res.json()) as QueryResponse
+}

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useRef, useState } from 'react'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { Separator } from '@/components/ui/separator'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { Send, ChevronLeft, ChevronRight, Pencil } from 'lucide-react'
+import {
+  listDbConnections,
+  listConversations,
+  createDbConnection,
+  updateDbConnection,
+  enableDbConnection,
+  disableDbConnection,
+  createConversation,
+  conversationQuery,
+  getConversation,
+} from '@/lib/api'
+import type { ChartData } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+export type Message = { id: string; role: 'user' | 'assistant'; content: string; pending?: boolean }
+
+type Props = { user: { id: string; username: string } }
+type DBConnItem = { id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }
+
+function formatContent(content: { text?: string; charts?: ChartData[] }): string {
+  if (content?.text) return content.text
+  if (content?.charts) {
+    return (
+      content.charts
+        .map((c: ChartData, i: number) => {
+          const r = c.reasoning ? `\nReasoning: ${c.reasoning}` : ''
+          return `Chart #${i + 1}: ${c.chart_type}${r}\nData: ${JSON.stringify(c.data, null, 2)}`
+        })
+        .join('\n\n') || 'No charts returned.'
+    )
+  }
+  return JSON.stringify(content)
+}
+
+function ChatBubble({ message }: { message: Message }) {
+  const isUser = message.role === 'user'
+  return (
+    <div className={cn('flex w-full gap-3', isUser ? 'justify-end' : 'justify-start')}>
+      {!isUser && (
+        <Avatar className="h-8 w-8">
+          <AvatarFallback>AI</AvatarFallback>
+        </Avatar>
+      )}
+      <div
+        className={cn(
+          'max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm',
+          isUser
+            ? 'bg-primary text-primary-foreground rounded-br-sm'
+            : 'bg-secondary text-secondary-foreground rounded-bl-sm'
+        )}
+      >
+        {message.pending ? (
+          <span className="inline-flex items-center gap-1 opacity-70">
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.2s]"></span>
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.1s]"></span>
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current"></span>
+          </span>
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
+        )}
+      </div>
+      {isUser && (
+        <Avatar className="h-8 w-8">
+          <AvatarFallback>U</AvatarFallback>
+        </Avatar>
+      )}
+    </div>
+  )
+}
+
+export default function Chat({ user }: Props) {
+  const [dbConns, setDbConns] = useState<DBConnItem[]>([])
+  const [convos, setConvos] = useState<{ id: string; title: string | null }[]>([])
+  const [selectedConn, setSelectedConn] = useState<string | undefined>()
+  const [connOpen, setConnOpen] = useState(false)
+  const [editingConn, setEditingConn] = useState<string | null>(null)
+  const [connForm, setConnForm] = useState({ db_name: '', host: '', port: 5432, user: '', password: '' })
+  const [currentConvo, setCurrentConvo] = useState<string | null>(null)
+  const [messagesMap, setMessagesMap] = useState<Record<string, Message[]>>({})
+  const [input, setInput] = useState('')
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    listDbConnections().then(setDbConns)
+    listConversations().then(setConvos)
+  }, [])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [messagesMap, currentConvo])
+
+  const messages = messagesMap[currentConvo ?? ''] || []
+
+  const handleSend = async () => {
+    const trimmed = input.trim()
+    if (!trimmed) return
+    let convoId = currentConvo
+    if (!convoId) {
+      if (!selectedConn) return
+      const { conversation_id } = await createConversation({
+        user_id: user.id,
+        db_connection_id: selectedConn,
+        title: trimmed.slice(0, 20),
+      })
+      convoId = conversation_id
+      setCurrentConvo(convoId)
+      setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
+    }
+    const id = crypto.randomUUID()
+    const loadingId = crypto.randomUUID()
+    setMessagesMap((prev) => ({
+      ...prev,
+      [convoId!]: [
+        ...(prev[convoId!] || []),
+        { id, role: 'user', content: trimmed },
+        { id: loadingId, role: 'assistant', content: '', pending: true },
+      ],
+    }))
+    setInput('')
+    const res = await conversationQuery(convoId!, {
+      prompt: trimmed,
+      available_charts: ['bar', 'line', 'pie'],
+      model_name: 'gpt-4o-mini',
+    })
+    const assistantText = formatContent({ charts: res.charts })
+    setMessagesMap((prev) => ({
+      ...prev,
+      [convoId!]: prev[convoId!].map((m) =>
+        m.id === loadingId ? { ...m, content: assistantText, pending: false } : m
+      ),
+    }))
+  }
+
+  const refreshConns = async () => setDbConns(await listDbConnections())
+
+  const handleSaveConn = async () => {
+    const body = { ...connForm, user_id: user.id }
+    if (editingConn) {
+      await updateDbConnection(editingConn, body)
+    } else {
+      await createDbConnection(body)
+    }
+    await refreshConns()
+    setConnOpen(false)
+  }
+
+  const handleToggleConn = async (id: string, enabled: boolean) => {
+    if (enabled) await disableDbConnection(id, user.id)
+    else await enableDbConnection(id, user.id)
+    await refreshConns()
+  }
+
+  const openAddConn = () => {
+    setEditingConn(null)
+    setConnForm({ db_name: '', host: '', port: 5432, user: '', password: '' })
+    setConnOpen(true)
+  }
+
+  const openEditConn = (c: DBConnItem) => {
+    setEditingConn(c.id)
+    setConnForm({ db_name: c.db_name, host: c.host, port: c.port, user: c.user, password: '' })
+    setConnOpen(true)
+  }
+
+  const handleSelectConvo = async (id: string) => {
+    setCurrentConvo(id)
+    if (!messagesMap[id]) {
+      const convo = await getConversation(id)
+      setMessagesMap((prev) => ({
+        ...prev,
+        [id]: convo.messages.map((m) => ({
+          id: m.id,
+          role: m.role as 'user' | 'assistant',
+          content: formatContent(m.content as { text?: string; charts?: ChartData[] }),
+        })),
+      }))
+    }
+  }
+
+  return (
+    <div className="flex h-dvh w-full">
+      <div className={cn('border-r overflow-y-auto transition-all', sidebarOpen ? 'w-64' : 'w-0')}> 
+        <div className={cn('p-2 space-y-2', sidebarOpen ? 'block' : 'hidden')}>
+          <div className="flex items-center justify-between">
+            <span className="font-semibold">Connections</span>
+            <Button size="sm" onClick={openAddConn}>Add</Button>
+          </div>
+          {dbConns.map((c) => (
+            <div key={c.id} className="flex items-center justify-between text-sm">
+              <span>{c.db_name}</span>
+              <div className="flex gap-1">
+                <Button size="sm" variant="outline" onClick={() => handleToggleConn(c.id, c.enabled)}>
+                  {c.enabled ? 'Disable' : 'Enable'}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => openEditConn(c)}>
+                  <Pencil className="h-3 w-3" />
+                </Button>
+              </div>
+            </div>
+          ))}
+          <Separator className="my-2" />
+          <div className="space-y-1">
+            {convos.map((c) => (
+              <div
+                key={c.id}
+                className={cn('p-2 cursor-pointer', c.id === currentConvo && 'bg-accent')}
+                onClick={() => handleSelectConvo(c.id)}
+              >
+                {c.title || 'Untitled'}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col relative">
+        <Button
+          variant="outline"
+          size="sm"
+          className="absolute top-2 left-2 z-10 h-8 w-8 p-0"
+          onClick={() => setSidebarOpen((o) => !o)}
+        >
+          {sidebarOpen ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </Button>
+        <ScrollArea className="flex-1 px-4 py-4">
+          <div className="flex flex-col gap-3">
+            {messages.map((m) => (
+              <ChatBubble key={m.id} message={m} />
+            ))}
+            <div ref={bottomRef} />
+          </div>
+        </ScrollArea>
+        <Separator />
+        <div className="px-4 pb-4 pt-2 flex items-center gap-2">
+          <Select
+            value={selectedConn}
+            onValueChange={(v: string) => {
+              if (v === 'add') {
+                openAddConn()
+              } else {
+                setSelectedConn(v)
+              }
+            }}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="DB Connection" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="add">Add connection</SelectItem>
+              {dbConns.map((c) => (
+                <SelectItem key={c.id} value={c.id} disabled={!c.enabled}>
+                  {c.db_name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            className="flex-1"
+            placeholder="Send a message..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleSend()
+              }
+            }}
+          />
+          <Button onClick={handleSend}>
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+      <Dialog open={connOpen} onOpenChange={setConnOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{editingConn ? 'Edit' : 'Add'} DB Connection</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input
+              placeholder="Database Name"
+              value={connForm.db_name}
+              onChange={(e) => setConnForm({ ...connForm, db_name: e.target.value })}
+            />
+            <Input
+              placeholder="Host"
+              value={connForm.host}
+              onChange={(e) => setConnForm({ ...connForm, host: e.target.value })}
+            />
+            <Input
+              placeholder="Port"
+              type="number"
+              value={connForm.port}
+              onChange={(e) => setConnForm({ ...connForm, port: Number(e.target.value) })}
+            />
+            <Input
+              placeholder="Username"
+              value={connForm.user}
+              onChange={(e) => setConnForm({ ...connForm, user: e.target.value })}
+            />
+            <Input
+              placeholder="Password"
+              type="password"
+              value={connForm.password}
+              onChange={(e) => setConnForm({ ...connForm, password: e.target.value })}
+            />
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button onClick={handleSaveConn}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog'
+import { loginApi, registerApi } from '@/lib/api'
+
+type Props = {
+  onLogin: (user: { id: string; username: string }) => void
+}
+
+export default function Login({ onLogin }: Props) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [open, setOpen] = useState(false)
+  const [reg, setReg] = useState({ name: '', email: '', password: '' })
+
+  const handleLogin = async () => {
+    const user = await loginApi({ username, password })
+    onLogin({ id: user.user_id, username: user.username })
+  }
+
+  const handleRegister = async () => {
+    await registerApi(reg)
+    setOpen(false)
+  }
+
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <div className="w-80 space-y-4">
+        <Input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <div className="space-y-2">
+          <Button className="w-full" onClick={handleLogin}>
+            Login
+          </Button>
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => setOpen(true)}
+          >
+            Create Account
+          </Button>
+        </div>
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Account</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input
+              placeholder="Username"
+              value={reg.name}
+              onChange={(e) => setReg({ ...reg, name: e.target.value })}
+            />
+            <Input
+              placeholder="Email"
+              value={reg.email}
+              onChange={(e) => setReg({ ...reg, email: e.target.value })}
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={reg.password}
+              onChange={(e) => setReg({ ...reg, password: e.target.value })}
+            />
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button onClick={handleRegister}>Register</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -1,13 +1,16 @@
 import os
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 
 from ....schemas import (
     ConversationCreateRequest,
     ConversationCreateResponse,
     ConversationQueryRequest,
     QueryResponse,
+    ConversationDetail,
+    ConversationListItem,
 )
 from ....services import conversation_service, llm_service
+from ....auth import verify_token
 
 router = APIRouter(prefix="/conversations")
 
@@ -15,7 +18,10 @@ router = APIRouter(prefix="/conversations")
 @router.post("", response_model=ConversationCreateResponse)
 async def create_conversation(
     request: ConversationCreateRequest,
+    token_data: dict = Depends(verify_token),
 ) -> ConversationCreateResponse:
+    if token_data["user_id"] != request.user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     conv_id = await conversation_service.create_conversation(
         request.user_id, request.db_connection_id, request.title, request.model
     )
@@ -24,7 +30,9 @@ async def create_conversation(
 
 @router.post("/{conversation_id}/query", response_model=QueryResponse)
 async def conversation_query(
-    conversation_id: str, request: ConversationQueryRequest
+    conversation_id: str,
+    request: ConversationQueryRequest,
+    token_data: dict = Depends(verify_token),
 ) -> QueryResponse:
     if not os.getenv("LLM_API_KEY"):
         raise HTTPException(status_code=500, detail="LLM_API_KEY not configured")
@@ -64,3 +72,22 @@ async def conversation_query(
     )
 
     return QueryResponse(charts=charts)
+
+
+@router.get("", response_model=list[ConversationListItem])
+async def list_conversations(token_data: dict = Depends(verify_token)):
+    conns = await conversation_service.list_conversations(token_data["user_id"])
+    return conns
+
+
+@router.get("/{conversation_id}", response_model=ConversationDetail)
+async def get_conversation(
+    conversation_id: str, token_data: dict = Depends(verify_token)
+):
+    try:
+        convo = await conversation_service.get_conversation(
+            conversation_id, token_data["user_id"]
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return convo

--- a/server/api/v1/routes/db_connections.py
+++ b/server/api/v1/routes/db_connections.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 
 from ....schemas import (
     DBConnectionCreateRequest,
@@ -6,8 +6,10 @@ from ....schemas import (
     DBConnectionUpdateRequest,
     DBConnectionToggleRequest,
     StatusResponse,
+    DBConnectionListItem,
 )
 from ....services import db_connection_service
+from ....auth import verify_token
 
 router = APIRouter(prefix="/db-connections")
 
@@ -15,7 +17,10 @@ router = APIRouter(prefix="/db-connections")
 @router.post("", response_model=DBConnectionCreateResponse)
 async def create_db_connection(
     request: DBConnectionCreateRequest,
+    token_data: dict = Depends(verify_token),
 ) -> DBConnectionCreateResponse:
+    if token_data["user_id"] != request.user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     conn_id = await db_connection_service.create_db_connection(
         request.user_id, request
     )
@@ -24,8 +29,12 @@ async def create_db_connection(
 
 @router.put("/{db_connection_id}", response_model=StatusResponse)
 async def update_db_connection(
-    db_connection_id: str, request: DBConnectionUpdateRequest
+    db_connection_id: str,
+    request: DBConnectionUpdateRequest,
+    token_data: dict = Depends(verify_token),
 ) -> StatusResponse:
+    if token_data["user_id"] != request.user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         await db_connection_service.update_db_connection(
             request.user_id, db_connection_id, request
@@ -37,8 +46,12 @@ async def update_db_connection(
 
 @router.post("/{db_connection_id}/disable", response_model=StatusResponse)
 async def disable_db_connection(
-    db_connection_id: str, request: DBConnectionToggleRequest
+    db_connection_id: str,
+    request: DBConnectionToggleRequest,
+    token_data: dict = Depends(verify_token),
 ) -> StatusResponse:
+    if token_data["user_id"] != request.user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         await db_connection_service.disable_db_connection(
             request.user_id, db_connection_id
@@ -50,8 +63,12 @@ async def disable_db_connection(
 
 @router.post("/{db_connection_id}/enable", response_model=StatusResponse)
 async def enable_db_connection(
-    db_connection_id: str, request: DBConnectionToggleRequest
+    db_connection_id: str,
+    request: DBConnectionToggleRequest,
+    token_data: dict = Depends(verify_token),
 ) -> StatusResponse:
+    if token_data["user_id"] != request.user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         await db_connection_service.enable_db_connection(
             request.user_id, db_connection_id
@@ -59,3 +76,11 @@ async def enable_db_connection(
     except ValueError as exc:
         raise HTTPException(status_code=403, detail=str(exc))
     return StatusResponse()
+
+
+@router.get("", response_model=list[DBConnectionListItem])
+async def list_db_connections(
+    token_data: dict = Depends(verify_token),
+):
+    conns = await db_connection_service.list_db_connections(token_data["user_id"])
+    return conns

--- a/server/api/v1/routes/query.py
+++ b/server/api/v1/routes/query.py
@@ -1,14 +1,17 @@
 import os
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 
 from ....schemas import QueryRequest, QueryResponse
 from ....services import llm_service
+from ....auth import verify_token
 
 router = APIRouter()
 
 
 @router.post("/query", response_model=QueryResponse)
-async def query_endpoint(request: QueryRequest) -> QueryResponse:
+async def query_endpoint(
+    request: QueryRequest, token_data: dict = Depends(verify_token)
+) -> QueryResponse:
     if not os.getenv("LLM_API_KEY"):
         raise HTTPException(status_code=500, detail="LLM_API_KEY not configured")
 

--- a/server/api/v1/routes/users.py
+++ b/server/api/v1/routes/users.py
@@ -1,12 +1,15 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends, Response
 
 from ....schemas import (
     UserCreateRequest,
     UserCreateResponse,
     UserUpdateRequest,
     StatusResponse,
+    LoginRequest,
+    LoginResponse,
 )
 from ....services import user_service
+from ....auth import create_access_token, verify_token, JWT_EXP_SECONDS
 
 router = APIRouter(prefix="/users")
 
@@ -18,9 +21,30 @@ async def create_user(request: UserCreateRequest) -> UserCreateResponse:
 
 
 @router.put("/{user_id}", response_model=StatusResponse)
-async def update_user(user_id: str, request: UserUpdateRequest) -> StatusResponse:
+async def update_user(
+    user_id: str,
+    request: UserUpdateRequest,
+    token_data: dict = Depends(verify_token),
+) -> StatusResponse:
+    if token_data["user_id"] != user_id:
+        raise HTTPException(status_code=403, detail="Forbidden")
     try:
         await user_service.update_user(user_id, request)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
     return StatusResponse()
+
+
+@router.post("/login", response_model=LoginResponse)
+async def login(response: Response, request: LoginRequest) -> LoginResponse:
+    user = await user_service.authenticate_user(request.username, request.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(user["user_id"], user["username"])
+    response.set_cookie(
+        "access_token",
+        token,
+        httponly=True,
+        max_age=JWT_EXP_SECONDS,
+    )
+    return LoginResponse(user_id=user["user_id"], username=user["username"])

--- a/server/auth.py
+++ b/server/auth.py
@@ -1,0 +1,29 @@
+import os
+from datetime import datetime, timedelta
+from typing import Optional, Dict
+
+import jwt
+from fastapi import HTTPException, Request
+
+JWT_SECRET = os.getenv("JWT_SECRET", "change-me")
+JWT_ALGORITHM = "HS256"
+JWT_EXP_SECONDS = int(os.getenv("JWT_EXP_SECONDS", "86400"))  # 1 day default
+
+
+def create_access_token(user_id: str, username: str, expires_delta: Optional[int] = None) -> str:
+    exp = datetime.utcnow() + timedelta(seconds=expires_delta or JWT_EXP_SECONDS)
+    payload = {"user_id": user_id, "username": username, "exp": exp}
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def verify_token(request: Request) -> Dict[str, str]:
+    token = request.cookies.get("access_token")
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing token")
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        return {"user_id": payload["user_id"], "username": payload["username"]}
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=401, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=401, detail="Invalid token")

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "langchain-community",
     "langchain-openai",
     "asyncpg",
+    "PyJWT",
 ]

--- a/server/schemas/__init__.py
+++ b/server/schemas/__init__.py
@@ -1,3 +1,4 @@
 from .user import *  # noqa: F401,F403
 from .db_connection import *  # noqa: F401,F403
 from .conversation import *  # noqa: F401,F403
+from .common import *  # noqa: F401,F403

--- a/server/schemas/common.py
+++ b/server/schemas/common.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class StatusResponse(BaseModel):
+    status: str = "ok"

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
 
 from .db_connection import DBConnection
@@ -48,3 +49,20 @@ class ConversationCreateResponse(BaseModel):
     """Response containing the new conversation id."""
 
     conversation_id: str
+
+
+class ConversationListItem(BaseModel):
+    id: str
+    title: Optional[str] = None
+
+
+class MessageItem(BaseModel):
+    id: str
+    role: str
+    content: Dict[str, Any]
+
+
+class ConversationDetail(BaseModel):
+    id: str
+    title: Optional[str] = None
+    messages: List[MessageItem]

--- a/server/schemas/db_connection.py
+++ b/server/schemas/db_connection.py
@@ -33,3 +33,12 @@ class DBConnectionToggleRequest(BaseModel):
     """Request body for enable/disable operations."""
 
     user_id: str
+
+
+class DBConnectionListItem(BaseModel):
+    id: str
+    db_name: str
+    host: str
+    port: int
+    user: str
+    enabled: bool

--- a/server/schemas/user.py
+++ b/server/schemas/user.py
@@ -22,3 +22,13 @@ class UserUpdateRequest(BaseModel):
     name: Optional[str] = None
     email: Optional[str] = None
     password: Optional[str] = None
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    user_id: str
+    username: str

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -1,9 +1,6 @@
 import json
 from typing import Any, Dict, Optional
 
-import json
-from typing import Any, Dict, Optional
-
 from ..db.database import get_pool
 from ..schemas.db_connection import DBConnection
 
@@ -103,3 +100,44 @@ async def get_context(conversation_id: str, limit: int = 20) -> Dict[str, Any]:
             {"role": r["role"], "content": r["content"]} for r in reversed(rows)
         ]
     return {"summary": summary, "messages": messages}
+
+
+async def list_conversations(user_id: str):
+    """Return ids and titles for a user's conversations."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id, title FROM conversation WHERE user_id=$1 ORDER BY created_at DESC",
+            user_id,
+        )
+    return [{"id": str(r["id"]), "title": r["title"]} for r in rows]
+
+
+async def get_conversation(conversation_id: str, user_id: str) -> Dict[str, Any]:
+    """Fetch a conversation with all its messages if owned by the user."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        convo = await conn.fetchrow(
+            "SELECT id, title FROM conversation WHERE id=$1 AND user_id=$2",
+            conversation_id,
+            user_id,
+        )
+        if not convo:
+            raise ValueError("Conversation not found")
+        rows = await conn.fetch(
+            """SELECT id, role, content FROM message
+            WHERE conversation_id=$1 ORDER BY created_at""",
+            conversation_id,
+        )
+    return {
+        "id": str(convo["id"]),
+        "title": convo["title"],
+        "messages": [
+            {
+                "id": str(r["id"]),
+                "role": r["role"],
+                "content": r["content"],
+            }
+            for r in rows
+        ],
+    }

--- a/server/services/db_connection_service.py
+++ b/server/services/db_connection_service.py
@@ -100,3 +100,32 @@ async def get_db_connection(db_connection_id: str) -> DBConnection:
             host=row["host"],
             port=row["port"],
         )
+
+
+async def list_db_connections(user_id: str):
+    """List connections for a user."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, db_name, db_user, host, port, enabled_at, disabled_at
+            FROM db_connection WHERE user_id=$1
+            """,
+            user_id,
+        )
+    result = []
+    for r in rows:
+        disabled_at = r["disabled_at"]
+        enabled_at = r["enabled_at"]
+        enabled = disabled_at is None or (enabled_at and disabled_at < enabled_at)
+        result.append(
+            {
+                "id": str(r["id"]),
+                "db_name": r["db_name"],
+                "host": r["host"],
+                "port": r["port"],
+                "user": r["db_user"],
+                "enabled": enabled,
+            }
+        )
+    return result

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -2,6 +2,23 @@ from ..db.database import get_pool
 from ..schemas.user import UserCreateRequest, UserUpdateRequest
 
 
+async def authenticate_user(username: str, password: str):
+    """Verify a user's credentials."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT id, name FROM app_user
+            WHERE name=$1 AND password=$2 AND deleted_at IS NULL
+            """,
+            username,
+            password,
+        )
+        if row:
+            return {"user_id": str(row["id"]), "username": row["name"]}
+        return None
+
+
 async def create_user(user: UserCreateRequest) -> str:
     """Insert a new application user and return its id."""
     pool = await get_pool()


### PR DESCRIPTION
## Summary
- use httpOnly cookies for JWT auth and set cookie on login
- allow fetching conversations with message history
- manage DB connections from sidebar and toggle sidebar visibility

## Testing
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d655d22dc83238488388980504f6d