### PR TITLE
feat(auth): hash user passwords

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -14,4 +14,5 @@ dependencies = [
     "langgraph",
     "sqlalchemy",
     "PyJWT",
+    "passlib[bcrypt]",
 ]

--- a/server/scripts/migrate_passwords.py
+++ b/server/scripts/migrate_passwords.py
@@ -1,0 +1,34 @@
+"""Utility to hash existing plain-text passwords in the database.
+
+Usage:
+    export DATABASE_URL=postgresql://user:password@host/dbname
+    python server/scripts/migrate_passwords.py
+"""
+
+import asyncio
+import os
+
+import asyncpg
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+async def migrate() -> None:
+    """Hash any plain-text passwords in the app_user table."""
+    dsn = os.environ["DATABASE_URL"]
+    pool = await asyncpg.create_pool(dsn)
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT id, password FROM app_user WHERE password NOT LIKE '$2b$%'"
+        )
+        for row in rows:
+            hashed = pwd_context.hash(row["password"])
+            await conn.execute(
+                "UPDATE app_user SET password=$1 WHERE id=$2", hashed, row["id"]
+            )
+    await pool.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(migrate())

--- a/server/services/user_service.py
+++ b/server/services/user_service.py
@@ -1,5 +1,19 @@
+from passlib.context import CryptContext
+
 from ..db.database import get_pool
 from ..schemas.user import UserCreateRequest, UserUpdateRequest
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _hash_password(password: str) -> str:
+    """Hash a plain-text password."""
+    return pwd_context.hash(password)
+
+
+def _verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plain-text password against a hash."""
+    return pwd_context.verify(plain_password, hashed_password)
 
 
 async def authenticate_user(username: str, password: str):
@@ -8,13 +22,12 @@ async def authenticate_user(username: str, password: str):
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
-            SELECT id, name FROM app_user
-            WHERE name=$1 AND password=$2 AND deleted_at IS NULL
+            SELECT id, name, password FROM app_user
+            WHERE name=$1 AND deleted_at IS NULL
             """,
             username,
-            password,
         )
-        if row:
+        if row and _verify_password(password, row["password"]):
             return {"user_id": str(row["id"]), "username": row["name"]}
         return None
 
@@ -30,7 +43,7 @@ async def create_user(user: UserCreateRequest) -> str:
             """,
             user.name,
             user.email,
-            user.password,
+            _hash_password(user.password),
         )
         return str(row["id"])
 
@@ -46,7 +59,7 @@ async def update_user(user_id: str, user: UserUpdateRequest) -> None:
         values.append(user.email)
         fields.append(f"email=${len(values)}")
     if user.password is not None:
-        values.append(user.password)
+        values.append(_hash_password(user.password))
         fields.append(f"password=${len(values)}")
     if not fields:
         return


### PR DESCRIPTION
## Summary
- add `passlib[bcrypt]` dependency for password hashing
- hash passwords on user creation/update and verify during authentication
- provide migration script to convert existing plain-text passwords to bcrypt hashes

## Testing
- `python -m py_compile server/services/user_service.py server/scripts/migrate_passwords.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17a434afc8323a210577b46dbd695