### PR TITLE
feat: add logout route and secure cookie handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Environment variables:
 - `LLM_API_KEY` – API key for the LLM provider
 - `JWT_SECRET` – secret used to sign JWTs (`change-me` default)
 - `JWT_EXP_SECONDS` – token lifetime in seconds (defaults to one day)
+- `ENVIRONMENT` – set to `production` to enable secure cookie settings
 
 ## API overview
 

--- a/server/api/v1/routes/users.py
+++ b/server/api/v1/routes/users.py
@@ -1,3 +1,5 @@
+import secrets
+
 from fastapi import APIRouter, HTTPException, Depends, Response
 
 from ....schemas import (
@@ -9,7 +11,14 @@ from ....schemas import (
     LoginResponse,
 )
 from ....services import user_service
-from ....auth import create_access_token, verify_token, JWT_EXP_SECONDS
+from ....auth import (
+    create_access_token,
+    verify_token,
+    verify_csrf,
+    JWT_EXP_SECONDS,
+    COOKIE_SECURE,
+    COOKIE_SAMESITE,
+)
 
 router = APIRouter(prefix="/users")
 
@@ -25,6 +34,7 @@ async def update_user(
     user_id: str,
     request: UserUpdateRequest,
     token_data: dict = Depends(verify_token),
+    _: None = Depends(verify_csrf),
 ) -> StatusResponse:
     if token_data["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Forbidden")
@@ -45,6 +55,41 @@ async def login(response: Response, request: LoginRequest) -> LoginResponse:
         "access_token",
         token,
         httponly=True,
+        secure=COOKIE_SECURE,
+        samesite=COOKIE_SAMESITE,
+        max_age=JWT_EXP_SECONDS,
+    )
+    # Issue a CSRF token for double-submit protection. Routes that mutate state
+    # should depend on `verify_csrf` to validate it.
+    csrf_token = secrets.token_urlsafe(32)
+    response.set_cookie(
+        "csrf_token",
+        csrf_token,
+        httponly=False,
+        secure=COOKIE_SECURE,
+        samesite=COOKIE_SAMESITE,
         max_age=JWT_EXP_SECONDS,
     )
     return LoginResponse(user_id=user["user_id"], username=user["username"])
+
+
+@router.post("/logout", response_model=StatusResponse)
+async def logout(response: Response) -> StatusResponse:
+    """Clear authentication and CSRF cookies."""
+    response.set_cookie(
+        "access_token",
+        "",
+        max_age=0,
+        httponly=True,
+        secure=COOKIE_SECURE,
+        samesite=COOKIE_SAMESITE,
+    )
+    response.set_cookie(
+        "csrf_token",
+        "",
+        max_age=0,
+        httponly=False,
+        secure=COOKIE_SECURE,
+        samesite=COOKIE_SAMESITE,
+    )
+    return StatusResponse()

--- a/server/auth.py
+++ b/server/auth.py
@@ -9,6 +9,11 @@ JWT_SECRET = os.getenv("JWT_SECRET", "change-me")
 JWT_ALGORITHM = "HS256"
 JWT_EXP_SECONDS = int(os.getenv("JWT_EXP_SECONDS", "86400"))  # 1 day default
 
+# Cookie settings
+IS_PRODUCTION = os.getenv("ENVIRONMENT") == "production"
+COOKIE_SECURE = IS_PRODUCTION
+COOKIE_SAMESITE = "none" if COOKIE_SECURE else "lax"
+
 
 def create_access_token(user_id: str, username: str, expires_delta: Optional[int] = None) -> str:
     exp = datetime.utcnow() + timedelta(seconds=expires_delta or JWT_EXP_SECONDS)
@@ -27,3 +32,14 @@ def verify_token(request: Request) -> Dict[str, str]:
         raise HTTPException(status_code=401, detail="Token expired")
     except jwt.InvalidTokenError:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def verify_csrf(request: Request) -> None:
+    """Simple double-submit CSRF protection.
+
+    Expects a matching token in the `csrf_token` cookie and `X-CSRF-Token` header.
+    """
+    cookie_token = request.cookies.get("csrf_token")
+    header_token = request.headers.get("X-CSRF-Token")
+    if not cookie_token or not header_token or cookie_token != header_token:
+        raise HTTPException(status_code=403, detail="CSRF validation failed")


### PR DESCRIPTION
## Summary
- add `/users/logout` endpoint to clear auth cookies
- secure cookie handling with `secure`, `httponly`, and `samesite` options
- issue CSRF tokens and stub verifier for state-changing requests
- document `ENVIRONMENT` variable for enabling production cookie security

## Testing
- `python -m py_compile server/auth.py server/api/v1/routes/users.py`
- `cd server && uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17a580f4c8323b99bc6a7cfede2ce