### PR TITLE
Use asyncio threads for LLM operations to improve concurrency

### DIFF
--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -58,10 +58,10 @@ async def conversation_query(
         conversation_id, "user", {"text": request.prompt}
     )
 
-    data = llm_service.extract_data(
+    data = await llm_service.extract_data(
         full_prompt, db_conn, request.model_name
     )
-    charts = llm_service.choose_charts(
+    charts = await llm_service.choose_charts(
         full_prompt, request.available_charts, data, request.model_name
     )
 

--- a/server/api/v1/routes/query.py
+++ b/server/api/v1/routes/query.py
@@ -1,4 +1,5 @@
 import os
+import asyncio
 from fastapi import APIRouter, HTTPException, Depends
 
 from ....schemas import QueryRequest, QueryResponse
@@ -26,7 +27,7 @@ async def query_endpoint(
         ),
     }
     try:
-        result = workflow.invoke(state_input)
+        result = await asyncio.to_thread(workflow.invoke, state_input)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     except Exception as exc:

--- a/server/services/llm_service.py
+++ b/server/services/llm_service.py
@@ -1,4 +1,5 @@
 """LLM-powered data extraction and chart recommendation utilities."""
+import asyncio
 import json
 import os
 from typing import Any, Dict, List
@@ -19,7 +20,9 @@ def _build_dsn(conn: DBConnection) -> str:
     )
 
 
-def extract_data(prompt: str, db_connection: DBConnection, model_name: str) -> List[Dict[str, Any]]:
+async def extract_data(
+    prompt: str, db_connection: DBConnection, model_name: str
+) -> List[Dict[str, Any]]:
     """Use LangChain's SQLAgent to fetch data from the database.
 
     The agent interprets ``prompt`` and runs whatever SQL queries are needed to
@@ -27,72 +30,81 @@ def extract_data(prompt: str, db_connection: DBConnection, model_name: str) -> L
     an object mapping column names to values.
     """
 
-    dsn = _build_dsn(db_connection)
-    db = SQLDatabase.from_uri(dsn)
-    llm = ChatOpenAI(model=model_name, api_key=os.environ["LLM_API_KEY"])
-    agent = create_sql_agent(llm, db, agent_type=AgentType.OPENAI_FUNCTIONS, verbose=False)
+    def _run() -> List[Dict[str, Any]]:
+        dsn = _build_dsn(db_connection)
+        db = SQLDatabase.from_uri(dsn)
+        llm = ChatOpenAI(model=model_name, api_key=os.environ["LLM_API_KEY"])
+        agent = create_sql_agent(
+            llm, db, agent_type=AgentType.OPENAI_FUNCTIONS, verbose=False
+        )
 
-    query = (
-        f"{prompt}\n" "Return the results as a JSON array of objects."
-    )
-    result = agent.invoke({"input": query})
-    data_text = result["output"] if isinstance(result, dict) else result
-    payload = json.loads(data_text)
-    if not isinstance(payload, list):
-        raise ValueError("Expected JSON array from SQL agent")
-    return payload
+        query = (f"{prompt}\n" "Return the results as a JSON array of objects.")
+        result = agent.invoke({"input": query})
+        data_text = result["output"] if isinstance(result, dict) else result
+        payload = json.loads(data_text)
+        if not isinstance(payload, list):
+            raise ValueError("Expected JSON array from SQL agent")
+        return payload
+
+    return await asyncio.to_thread(_run)
 
 
-def choose_charts(
-    prompt: str, available_charts: List[str], data: List[Dict[str, Any]], model_name: str
+async def choose_charts(
+    prompt: str,
+    available_charts: List[str],
+    data: List[Dict[str, Any]],
+    model_name: str,
 ) -> List[ChartData]:
     """Ask the LLM to pick chart types and shape data for each chart."""
 
-    client = OpenAI(api_key=os.environ["LLM_API_KEY"])
+    def _run() -> List[ChartData]:
+        client = OpenAI(api_key=os.environ["LLM_API_KEY"])
 
-    response_format = {
-        "type": "json_schema",
-        "json_schema": {
-            "name": "chart_recommendations",
-            "schema": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "chart_type": {
-                            "type": "string",
-                            "enum": available_charts,
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "chart_recommendations",
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "chart_type": {
+                                "type": "string",
+                                "enum": available_charts,
+                            },
+                            "data": {"type": "object"},
+                            "reasoning": {"type": "string"},
                         },
-                        "data": {"type": "object"},
-                        "reasoning": {"type": "string"},
+                        "required": ["chart_type", "data"],
                     },
-                    "required": ["chart_type", "data"],
                 },
             },
-        },
-    }
+        }
 
-    message = (
-        "Choose suitable charts for the user's request and shape the data for each selection.\n"\
-        + f"User request: {prompt}\n"\
-        + f"Available chart types: {available_charts}\n"\
-        + f"Data: {json.dumps(data)}"
-    )
-
-    resp = client.responses.create(
-        model=model_name,
-        input=message,
-        response_format=response_format,
-    )
-
-    selections = json.loads(resp.output[0].content[0].text)
-    charts: List[ChartData] = []
-    for item in selections:
-        charts.append(
-            ChartData(
-                chart_type=item["chart_type"],
-                data=item["data"],
-                reasoning=item.get("reasoning"),
-            )
+        message = (
+            "Choose suitable charts for the user's request and shape the data for each selection.\n"
+            + f"User request: {prompt}\n"
+            + f"Available chart types: {available_charts}\n"
+            + f"Data: {json.dumps(data)}"
         )
-    return charts
+
+        resp = client.responses.create(
+            model=model_name,
+            input=message,
+            response_format=response_format,
+        )
+
+        selections = json.loads(resp.output[0].content[0].text)
+        charts: List[ChartData] = []
+        for item in selections:
+            charts.append(
+                ChartData(
+                    chart_type=item["chart_type"],
+                    data=item["data"],
+                    reasoning=item.get("reasoning"),
+                )
+            )
+        return charts
+
+    return await asyncio.to_thread(_run)


### PR DESCRIPTION
## Summary
- Offload blocking LLM database and chart selection calls to `asyncio.to_thread` for true async interfaces
- Await new async services in conversation routes and run workflow invocation in a thread

## Testing
- `pytest -q`
- Simulated concurrent `query_endpoint` calls showing ~1s completion for two simultaneous requests
- Simulated concurrent `conversation_query` calls completing in ~2s for two requests with blocking stubs


------
https://chatgpt.com/codex/tasks/task_e_68a17a4c93448323b0b6a11e4ffb3b07