### PR TITLE
Add logging for summarization failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ React + Vite front end and a FastAPI backend.
 - Toggleable sidebar for switching conversations and configuring connections
 - Conversations are summarized after each assistant reply to keep context
   within token limits, and each summary records its last refresh time
+- Summarization failures are logged and warnings emitted after repeated errors
 
 ## Structure
 
@@ -40,6 +41,7 @@ Environment variables:
 - `ENVIRONMENT` – set to `production` to enable secure cookie settings
 - `LLM_RESPONSE_MODEL` – LLM model used for final summaries
 - `DATABASE_URL` – connection string for the application's metadata DB
+- `LOG_LEVEL` – logging level for the backend (default `INFO`)
 
 ## API overview
 

--- a/server/config.py
+++ b/server/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     JWT_EXP_SECONDS: int = 86400
     ENVIRONMENT: str = "development"
     LLM_RESPONSE_MODEL: str = "gpt-4o-mini"
+    LOG_LEVEL: str = "INFO"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,6 @@
 """FastAPI application serving the data analyst chatbot."""
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -6,6 +8,11 @@ from .api.v1.routes import (
     users_router,
     db_connections_router,
     conversations_router,
+)
+from .config import settings
+
+logging.basicConfig(
+    level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO)
 )
 
 app = FastAPI(title="LLM Data Analyst")

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -1,9 +1,15 @@
 import asyncio
 import json
+import logging
+from collections import Counter
 from typing import Any, Dict, Optional
 
 from ..db.database import get_pool
 from ..schemas.db_connection import DBConnection
+
+
+logger = logging.getLogger(__name__)
+_summary_failures: Counter[str] = Counter()
 
 
 def _estimate_tokens_from_text(text: str) -> int:
@@ -183,9 +189,15 @@ async def summarize_conversation(conversation_id: str, token_limit: int = 1000) 
                     last_message_id,
                     token_count,
                 )
-    except Exception:
-        # Background task should not raise; ignore failures silently.
-        pass
+    except Exception as e:
+        _summary_failures[conversation_id] += 1
+        logger.exception("Failed to summarize conversation %s: %s", conversation_id, e)
+        if _summary_failures[conversation_id] >= 3:
+            logger.warning(
+                "Conversation %s has %d summarization failures",
+                conversation_id,
+                _summary_failures[conversation_id],
+            )
 
 
 async def get_context(


### PR DESCRIPTION
## Summary
- configure global log level via `LOG_LEVEL` setting
- log conversation summarization failures and warn on repeated errors
- document new logging behavior and setting

## Testing
- `cd server && uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3da339be08323a56e755f9166f50e