### PR TITLE
Handle client API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ React + Vite front end and a FastAPI backend.
 - Toggleable sidebar for switching conversations and configuring connections
 - Conversations are summarized after each assistant reply to keep context
   within token limits, and each summary records its last refresh time
+- Inline error messages with cleared loading indicators for failed API calls
 
 ## Structure
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -18,117 +18,116 @@ export type QueryResponse = {
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
 
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, options)
+  if (!res.ok) {
+    let message = 'Request failed'
+    try {
+      const data = await res.json()
+      message = data?.detail || message
+    } catch {
+      message = res.statusText || message
+    }
+    throw new Error(message)
+  }
+  return (await res.json()) as T
+}
+
 export async function loginApi(body: { username: string; password: string }) {
-  const res = await fetch(`${API_BASE}/users/login`, {
+  return fetchJson<{ user_id: string; username: string }>(`${API_BASE}/users/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Login failed')
-  return (await res.json()) as { user_id: string; username: string }
 }
 
 export async function registerApi(body: { name: string; email: string; password: string }) {
-  const res = await fetch(`${API_BASE}/users`, {
+  return fetchJson<{ user_id: string }>(`${API_BASE}/users`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error('Register failed')
-  return (await res.json()) as { user_id: string }
 }
 
 export async function listDbConnections() {
-  const res = await fetch(`${API_BASE}/db-connections`, {
-    credentials: 'include',
-  })
-  if (!res.ok) throw new Error('Failed to list connections')
-  return (await res.json()) as { id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }[]
+  return fetchJson<{ id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }[]>(
+    `${API_BASE}/db-connections`,
+    {
+      credentials: 'include',
+    }
+  )
 }
 
 export async function createDbConnection(body: DBConnection & { user_id: string }) {
-  const res = await fetch(`${API_BASE}/db-connections`, {
+  return fetchJson<{ db_connection_id: string }>(`${API_BASE}/db-connections`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to create connection')
-  return (await res.json()) as { db_connection_id: string }
 }
 
 export async function updateDbConnection(id: string, body: DBConnection & { user_id: string }) {
-  const res = await fetch(`${API_BASE}/db-connections/${id}`, {
+  return fetchJson<{ status: string }>(`${API_BASE}/db-connections/${id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to update connection')
-  return (await res.json()) as { status: string }
 }
 
 export async function enableDbConnection(id: string, user_id: string) {
-  const res = await fetch(`${API_BASE}/db-connections/${id}/enable`, {
+  return fetchJson<{ status: string }>(`${API_BASE}/db-connections/${id}/enable`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id }),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to enable connection')
-  return (await res.json()) as { status: string }
 }
 
 export async function disableDbConnection(id: string, user_id: string) {
-  const res = await fetch(`${API_BASE}/db-connections/${id}/disable`, {
+  return fetchJson<{ status: string }>(`${API_BASE}/db-connections/${id}/disable`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user_id }),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to disable connection')
-  return (await res.json()) as { status: string }
 }
 
 export async function listConversations() {
-  const res = await fetch(`${API_BASE}/conversations`, {
+  return fetchJson<{ id: string; title: string | null }[]>(`${API_BASE}/conversations`, {
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to list conversations')
-  return (await res.json()) as { id: string; title: string | null }[]
 }
 
 export async function getConversation(id: string) {
-  const res = await fetch(`${API_BASE}/conversations/${id}`, {
-    credentials: 'include',
-  })
-  if (!res.ok) throw new Error('Failed to get conversation')
-  return (await res.json()) as {
+  return fetchJson<{
     id: string
     title: string | null
     messages: { id: string; role: string; content: unknown }[]
-  }
+  }>(`${API_BASE}/conversations/${id}`, {
+    credentials: 'include',
+  })
 }
 
 export async function createConversation(body: { user_id: string; db_connection_id: string; title?: string; model?: string }) {
-  const res = await fetch(`${API_BASE}/conversations`, {
+  return fetchJson<{ conversation_id: string }>(`${API_BASE}/conversations`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Failed to create conversation')
-  return (await res.json()) as { conversation_id: string }
 }
 
-export async function conversationQuery(conversation_id: string, body: { prompt: string; available_charts: string[]; model_name: string }) {
-  const res = await fetch(`${API_BASE}/conversations/${conversation_id}/query`, {
+export async function conversationQuery(
+  conversation_id: string,
+  body: { prompt: string; available_charts: string[]; model_name: string }
+) {
+  return fetchJson<QueryResponse>(`${API_BASE}/conversations/${conversation_id}/query`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
     credentials: 'include',
   })
-  if (!res.ok) throw new Error('Query failed')
-  return (await res.json()) as QueryResponse
 }

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -96,10 +96,24 @@ export default function Chat({ user }: Props) {
   const [input, setInput] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const bottomRef = useRef<HTMLDivElement | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+  const [connLoading, setConnLoading] = useState(false)
 
   useEffect(() => {
-    listDbConnections().then(setDbConns)
-    listConversations().then(setConvos)
+    const load = async () => {
+      try {
+        const [dbs, convs] = await Promise.all([
+          listDbConnections(),
+          listConversations(),
+        ])
+        setDbConns(dbs)
+        setConvos(convs)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data')
+      }
+    }
+    load()
   }, [])
 
   useEffect(() => {
@@ -111,60 +125,94 @@ export default function Chat({ user }: Props) {
   const handleSend = async () => {
     const trimmed = input.trim()
     if (!trimmed) return
+    setError(null)
+    setSending(true)
     let convoId = currentConvo
-    if (!convoId) {
-      if (!selectedConn) return
-      const { conversation_id } = await createConversation({
-        user_id: user.id,
-        db_connection_id: selectedConn,
-        title: trimmed.slice(0, 20),
+    let loadingId: string | undefined
+    try {
+      if (!convoId) {
+        if (!selectedConn) return
+        const { conversation_id } = await createConversation({
+          user_id: user.id,
+          db_connection_id: selectedConn,
+          title: trimmed.slice(0, 20),
+        })
+        convoId = conversation_id
+        setCurrentConvo(convoId)
+        setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
+      }
+      const id = crypto.randomUUID()
+      loadingId = crypto.randomUUID()
+      setMessagesMap((prev) => ({
+        ...prev,
+        [convoId!]: [
+          ...(prev[convoId!] || []),
+          { id, role: 'user', content: trimmed },
+          { id: loadingId, role: 'assistant', content: '', pending: true },
+        ],
+      }))
+      setInput('')
+      const res = await conversationQuery(convoId!, {
+        prompt: trimmed,
+        available_charts: ['bar', 'line', 'pie'],
+        model_name: 'gpt-4o-mini',
       })
-      convoId = conversation_id
-      setCurrentConvo(convoId)
-      setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
+      const assistantText = formatContent({ charts: res.charts })
+      setMessagesMap((prev) => ({
+        ...prev,
+        [convoId!]: prev[convoId!].map((m) =>
+          m.id === loadingId ? { ...m, content: assistantText, pending: false } : m
+        ),
+      }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message')
+      if (convoId && loadingId) {
+        setMessagesMap((prev) => ({
+          ...prev,
+          [convoId!]: prev[convoId!].filter((m) => m.id !== loadingId),
+        }))
+      }
+    } finally {
+      setSending(false)
     }
-    const id = crypto.randomUUID()
-    const loadingId = crypto.randomUUID()
-    setMessagesMap((prev) => ({
-      ...prev,
-      [convoId!]: [
-        ...(prev[convoId!] || []),
-        { id, role: 'user', content: trimmed },
-        { id: loadingId, role: 'assistant', content: '', pending: true },
-      ],
-    }))
-    setInput('')
-    const res = await conversationQuery(convoId!, {
-      prompt: trimmed,
-      available_charts: ['bar', 'line', 'pie'],
-      model_name: 'gpt-4o-mini',
-    })
-    const assistantText = formatContent({ charts: res.charts })
-    setMessagesMap((prev) => ({
-      ...prev,
-      [convoId!]: prev[convoId!].map((m) =>
-        m.id === loadingId ? { ...m, content: assistantText, pending: false } : m
-      ),
-    }))
   }
 
-  const refreshConns = async () => setDbConns(await listDbConnections())
+  const refreshConns = async () => {
+    try {
+      setDbConns(await listDbConnections())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to refresh connections')
+    }
+  }
 
   const handleSaveConn = async () => {
+    setError(null)
+    setConnLoading(true)
     const body = { ...connForm, user_id: user.id }
-    if (editingConn) {
-      await updateDbConnection(editingConn, body)
-    } else {
-      await createDbConnection(body)
+    try {
+      if (editingConn) {
+        await updateDbConnection(editingConn, body)
+      } else {
+        await createDbConnection(body)
+      }
+      await refreshConns()
+      setConnOpen(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save connection')
+    } finally {
+      setConnLoading(false)
     }
-    await refreshConns()
-    setConnOpen(false)
   }
 
   const handleToggleConn = async (id: string, enabled: boolean) => {
-    if (enabled) await disableDbConnection(id, user.id)
-    else await enableDbConnection(id, user.id)
-    await refreshConns()
+    setError(null)
+    try {
+      if (enabled) await disableDbConnection(id, user.id)
+      else await enableDbConnection(id, user.id)
+      await refreshConns()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update connection')
+    }
   }
 
   const openAddConn = () => {
@@ -182,15 +230,19 @@ export default function Chat({ user }: Props) {
   const handleSelectConvo = async (id: string) => {
     setCurrentConvo(id)
     if (!messagesMap[id]) {
-      const convo = await getConversation(id)
-      setMessagesMap((prev) => ({
-        ...prev,
-        [id]: convo.messages.map((m) => ({
-          id: m.id,
-          role: m.role as 'user' | 'assistant',
-          content: formatContent(m.content as { text?: string; charts?: ChartData[] }),
-        })),
-      }))
+      try {
+        const convo = await getConversation(id)
+        setMessagesMap((prev) => ({
+          ...prev,
+          [id]: convo.messages.map((m) => ({
+            id: m.id,
+            role: m.role as 'user' | 'assistant',
+            content: formatContent(m.content as { text?: string; charts?: ChartData[] }),
+          })),
+        }))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load conversation')
+      }
     }
   }
 
@@ -246,6 +298,7 @@ export default function Chat({ user }: Props) {
             <div ref={bottomRef} />
           </div>
         </ScrollArea>
+        {error && <p className="px-4 text-sm text-red-500">{error}</p>}
         <Separator />
         <div className="px-4 pb-4 pt-2 flex items-center gap-2">
           <Select
@@ -282,7 +335,7 @@ export default function Chat({ user }: Props) {
               }
             }}
           />
-          <Button onClick={handleSend}>
+          <Button onClick={handleSend} disabled={sending}>
             <Send className="h-4 w-4" />
           </Button>
         </div>
@@ -325,7 +378,9 @@ export default function Chat({ user }: Props) {
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>
-            <Button onClick={handleSaveConn}>Save</Button>
+            <Button onClick={handleSaveConn} disabled={connLoading}>
+              {connLoading ? 'Saving...' : 'Save'}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -20,15 +20,35 @@ export default function Login({ onLogin }: Props) {
   const [password, setPassword] = useState('')
   const [open, setOpen] = useState(false)
   const [reg, setReg] = useState({ name: '', email: '', password: '' })
+  const [loginError, setLoginError] = useState<string | null>(null)
+  const [regError, setRegError] = useState<string | null>(null)
+  const [loginLoading, setLoginLoading] = useState(false)
+  const [regLoading, setRegLoading] = useState(false)
 
   const handleLogin = async () => {
-    const user = await loginApi({ username, password })
-    onLogin({ id: user.user_id, username: user.username })
+    setLoginError(null)
+    setLoginLoading(true)
+    try {
+      const user = await loginApi({ username, password })
+      onLogin({ id: user.user_id, username: user.username })
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : 'Login failed')
+    } finally {
+      setLoginLoading(false)
+    }
   }
 
   const handleRegister = async () => {
-    await registerApi(reg)
-    setOpen(false)
+    setRegError(null)
+    setRegLoading(true)
+    try {
+      await registerApi(reg)
+      setOpen(false)
+    } catch (err) {
+      setRegError(err instanceof Error ? err.message : 'Registration failed')
+    } finally {
+      setRegLoading(false)
+    }
   }
 
   return (
@@ -45,9 +65,10 @@ export default function Login({ onLogin }: Props) {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
+        {loginError && <p className="text-sm text-red-500">{loginError}</p>}
         <div className="space-y-2">
-          <Button className="w-full" onClick={handleLogin}>
-            Login
+          <Button className="w-full" onClick={handleLogin} disabled={loginLoading}>
+            {loginLoading ? 'Logging in...' : 'Login'}
           </Button>
           <Button
             variant="outline"
@@ -80,12 +101,15 @@ export default function Login({ onLogin }: Props) {
               value={reg.password}
               onChange={(e) => setReg({ ...reg, password: e.target.value })}
             />
+            {regError && <p className="text-sm text-red-500">{regError}</p>}
           </div>
           <DialogFooter>
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>
             </DialogClose>
-            <Button onClick={handleRegister}>Register</Button>
+            <Button onClick={handleRegister} disabled={regLoading}>
+              {regLoading ? 'Registering...' : 'Register'}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary
- centralize fetch error handling with shared `fetchJson`
- show inline errors and clear loading states in login and chat flows
- document frontend error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3da394ec4832393ff76a0a37c4ed0