### PR TITLE
Use conversation service for summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ flowchart TD
 Advice-only paths bypass data retrieval and visualization, generating a
 direct narrative response from the user's prompt.
 
+During the **Conversation summary** step, the workflow calls the conversation
+service to generate and persist a running summary of the dialogue. The returned
+text and the id of the last processed message are stored in the database and
+made available to downstream nodes via the workflow state.
+
 ### Data model
 
 ```mermaid

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 from collections import Counter
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from ..db.database import get_pool
 from ..schemas.db_connection import DBConnection
@@ -109,13 +109,18 @@ async def add_message(
     return message_id
 
 
-async def summarize_conversation(conversation_id: str, token_limit: int = 1000) -> None:
+async def summarize_conversation(
+    conversation_id: str, token_limit: int = 1000
+) -> Optional[Tuple[str, str]]:
     """Summarize conversation messages and upsert into convo_summary.
 
     The summary concatenates the existing summary (if any) with new messages
     since the last summarized message. The resulting text is truncated to
     ``token_limit`` tokens (approximate) and stored along with the id of the
     latest message it covers.
+
+    Returns:
+        Tuple of ``(summary_text, last_message_id)`` if successful, otherwise ``None``.
     """
     pool = await get_pool()
     try:
@@ -128,6 +133,7 @@ async def summarize_conversation(conversation_id: str, token_limit: int = 1000) 
                 """,
                 conversation_id,
             )
+            summary_text = summary_row["summary"] if summary_row else ""
             last_message_id = summary_row["last_message_id"] if summary_row else None
             last_created_at = None
             if last_message_id:
@@ -147,10 +153,10 @@ async def summarize_conversation(conversation_id: str, token_limit: int = 1000) 
                 last_created_at,
             )
             if not rows:
-                return
+                return summary_text, last_message_id
             parts = []
-            if summary_row:
-                parts.append(summary_row["summary"])
+            if summary_text:
+                parts.append(summary_text)
             for r in rows:
                 text = r["content"].get("text") if isinstance(r["content"], dict) else None
                 if text:
@@ -189,6 +195,7 @@ async def summarize_conversation(conversation_id: str, token_limit: int = 1000) 
                     last_message_id,
                     token_count,
                 )
+            return summary_text, last_message_id
     except Exception as e:
         _summary_failures[conversation_id] += 1
         logger.exception("Failed to summarize conversation %s: %s", conversation_id, e)
@@ -198,6 +205,7 @@ async def summarize_conversation(conversation_id: str, token_limit: int = 1000) 
                 conversation_id,
                 _summary_failures[conversation_id],
             )
+    return None
 
 
 async def get_context(

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -13,6 +13,7 @@ contextual details:
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Dict, List, TypedDict
@@ -21,6 +22,7 @@ from langgraph.graph import END, StateGraph
 from openai import OpenAI
 
 from ..config import settings
+from ..services import conversation_service
 from sqlalchemy import MetaData, Table, create_engine, func, inspect, select
 
 
@@ -320,7 +322,23 @@ def result_validation(state: WorkflowState) -> WorkflowState:
 def conversation_summary(state: WorkflowState) -> WorkflowState:
     """Summarize the conversation and log outputs."""
     logger.info("Step 9: Conversation summary & logging")
-    state["summary"] = "Conversation summarized."
+    conv_id = state.get("conversation_id")
+    if conv_id:
+        try:
+            try:
+                result = asyncio.run(
+                    conversation_service.summarize_conversation(conv_id)
+                )
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+                result = loop.run_until_complete(
+                    conversation_service.summarize_conversation(conv_id)
+                )
+            if result:
+                summary_text, _last_id = result
+                state["summary"] = summary_text
+        except Exception:
+            logger.exception("Conversation summarization failed for %s", conv_id)
     return state
 
 


### PR DESCRIPTION
## Summary
- Summarize conversations using `conversation_service.summarize_conversation` inside workflow and expose the result in state
- Return summary text from `summarize_conversation` and persist it with last processed message
- Document workflow conversation summary step

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a43773e944832395e1ce3e07a67f65