### PR TITLE
feat: classify intent with llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ React + Vite front end and a FastAPI backend.
   within token limits, and each summary records its last refresh time
 - Inline error messages with cleared loading indicators for failed API calls
 - Summarization failures are logged and warnings emitted after repeated errors
+- Intent classification and entity extraction are handled by an LLM instead of keyword heuristics
 
 ## Structure
 
@@ -124,7 +125,9 @@ sequenceDiagram
 ### AI workflow steps
 
 The assistant adapts its path based on the user's intent. After any
-clarification, requests branch into advice or data-driven flows.
+clarification, requests branch into advice or data-driven flows. Intent and
+entity recognition are powered by an LLM that extracts metrics, dimensions, and
+timeframes from the user's prompt.
 
 ```mermaid
 flowchart TD

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -64,9 +64,56 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
     """Classify intent, extract entities, and apply default assumptions."""
     logger.info("Step 2: Intent & query understanding")
 
+    prompt = state.get("prompt", "")
+    client = OpenAI(api_key=settings.LLM_API_KEY)
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "intent_extraction",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "intent": {"type": "string"},
+                    "entities": {
+                        "type": "object",
+                        "properties": {
+                            "metrics": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "dimensions": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "timeframe": {"type": "string"},
+                        },
+                    },
+                },
+                "required": ["intent", "entities"],
+            },
+        },
+    }
+    message = (
+        "Determine the user's intent (analysis or advice) and extract any metrics, "
+        "dimensions, and timeframe mentioned.\n"
+        f"User request: {prompt}"
+    )
+    try:
+        resp = client.responses.create(
+            model=settings.LLM_RESPONSE_MODEL,
+            input=message,
+            response_format=response_format,
+        )
+        parsed = json.loads(resp.output[0].content[0].text)
+    except Exception as exc:  # pragma: no cover - LLM failure fallback
+        logger.exception("Failed to parse intent response: %s", exc)
+        parsed = {"intent": "analysis", "entities": {}}
+
     entities = state.get("entities", {})
     entities.setdefault("timezone", "Asia/Singapore")
     entities.setdefault("currency", "single assumed currency")
+    entities.update(parsed.get("entities", {}))
+    intent = parsed.get("intent", "analysis")
 
     questions: List[str] = []
     if not entities.get("timeframe"):
@@ -76,12 +123,6 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
         questions.append("Which metrics are you interested in?")
     if not entities.get("dimensions"):
         questions.append("Which dimensions should the data be grouped by?")
-
-    prompt = state.get("prompt", "").lower()
-    if any(k in prompt for k in ["suggest", "recommend", "advice", "advise"]):
-        intent = "advice"
-    else:
-        intent = "analysis"
 
     state["entities"] = entities
     state["intent"] = state.get("intent", intent)


### PR DESCRIPTION
## Summary
- leverage LLM to classify user intent and pull metrics, dimensions, and timeframe
- parse LLM JSON output into workflow state and drop keyword heuristics
- document LLM-based intent handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4378209ec8323958f7a4c74eba674