### PR TITLE
feat: clarify follow-ups in conversation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,21 @@ JWT cookie unless noted.
 - `GET /conversations` – list conversations for the current user
 - `GET /conversations/{id}` – fetch a conversation with its messages
 - `POST /conversations` – create a conversation bound to a DB connection
-- `POST /conversations/{id}/query` – send a prompt and receive chart data
+- `POST /conversations/{id}/query` – send a prompt and receive chart data. If
+  clarification is needed, the response includes `needs_clarification` and a
+  list of `clarification_questions`. Answer them using the
+  `clarification_answers` field in a follow-up request.
 
 ## Backend workflow
 
 Each conversation stores the database connection it should use. When a user
 sends a query, the API fetches the associated connection, gathers recent
-messages for context, and calls the LLM to produce chart-ready data. The
-resulting chart suggestions are saved as assistant messages. After each
-assistant response, the conversation is summarized and stored so later
-requests only need the summary plus the most recent messages.
+messages for context, and checks whether more details are needed. If so, it
+returns clarification questions before running any SQL. Otherwise it calls the
+LLM to produce chart-ready data. The resulting chart suggestions are saved as
+assistant messages. After each assistant response, the conversation is
+summarized and stored so later requests only need the summary plus the most
+recent messages.
 
 ```mermaid
 flowchart LR

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -8,6 +8,7 @@ from ....schemas import (
     ConversationListItem,
 )
 from ....services import conversation_service, llm_service
+from ....workflows.ai_workflow import intent_understanding, clarification
 from ....auth import verify_token
 from ....config import settings
 
@@ -58,6 +59,18 @@ async def conversation_query(
     await conversation_service.add_message(
         conversation_id, "user", {"text": request.prompt}
     )
+
+    state = {"prompt": request.prompt}
+    if request.clarification_answers:
+        state["clarification_answers"] = request.clarification_answers
+    state = intent_understanding(state)
+    state = clarification(state)
+    if state.get("needs_clarification"):
+        return QueryResponse(
+            charts=[],
+            needs_clarification=True,
+            clarification_questions=state.get("clarification_questions", []),
+        )
 
     data = await llm_service.extract_data(
         full_prompt, db_conn, request.model_name

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -18,12 +18,15 @@ class ConversationQueryRequest(BaseModel):
     prompt: str
     available_charts: List[str]
     model_name: str
+    clarification_answers: Optional[Dict[str, Any]] = None
 
 
 class QueryResponse(BaseModel):
     """Response payload containing chart suggestions and data."""
 
     charts: List[ChartData]
+    needs_clarification: bool = False
+    clarification_questions: Optional[List[str]] = None
 
 
 class ConversationCreateRequest(BaseModel):

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -332,7 +332,13 @@ def monitoring(state: WorkflowState) -> WorkflowState:
 
 def clarification_router(state: WorkflowState) -> str:
     """Route back for questions, escalate, or continue if complete."""
-    if state.get("needs_clarification") or state.get("clarification_escalated"):
+    if state.get("needs_clarification"):
+        attempts = state.get("clarification_attempts", 0)
+        limit = state.get("clarification_limit", 3)
+        if not state.get("clarification_escalated") and attempts < limit:
+            return "intent_understanding"
+        return END
+    if state.get("clarification_escalated"):
         return END
     return "task_planning"
 


### PR DESCRIPTION
## Summary
- return clarification questions when more info is needed
- allow answering questions via `clarification_answers`
- keep clarification loop in workflow until answers provided or limit reached

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4377bc1788323ae1c77af8aa8e718