### PR TITLE
Use workflow for conversation queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,23 +68,24 @@ JWT cookie unless noted.
 - `GET /conversations` – list conversations for the current user
 - `GET /conversations/{id}` – fetch a conversation with its messages
 - `POST /conversations` – create a conversation bound to a DB connection
-- `POST /conversations/{id}/query` – send a prompt and receive chart data
+- `POST /conversations/{id}/query` – run the AI workflow and receive a response and chart spec
 
 ## Backend workflow
 
 Each conversation stores the database connection it should use. When a user
 sends a query, the API fetches the associated connection, gathers recent
-messages for context, and calls the LLM to produce chart-ready data. The
-resulting chart suggestions are saved as assistant messages. After each
-assistant response, the conversation is summarized and stored so later
-requests only need the summary plus the most recent messages.
+messages for context, and runs a LangGraph-based workflow. The workflow may
+query the database and call the LLM to produce a narrative response and chart
+specification, which are saved as assistant messages. After each assistant
+response, the conversation is summarized and stored so later requests only
+need the summary plus the most recent messages.
 
 ```mermaid
 flowchart LR
     U[User] -->|query| API
     API -->|lookup| DB[(PostgreSQL)]
-    API -->|prompt + data| LLM
-    LLM -->|charts| API
+    API -->|workflow| LLM
+    LLM -->|response + chart spec| API
     API -->|assistant message| DB
     API -->|response| U
 ```
@@ -101,25 +102,18 @@ sequenceDiagram
     U->>API: POST /conversations/{id}/query
     API->>DB: Fetch conversation & selected connection
     API->>DB: Load recent messages for context
-    API->>LLM: Prompt with messages and schema
-    LLM-->>API: SQL + chart plan
-    API->>DB: Execute SQL on bound connection
-    DB-->>API: Result rows
-    API->>LLM: Summarize rows into chart data
-    LLM-->>API: Chart spec + summary
+    API->>LLM: Run workflow with prompt and context
+    LLM-->>API: Response + chart spec
     API->>DB: Persist assistant response
-    API-->>U: Return chart suggestion
+    API-->>U: Return response + chart spec
 ```
 
 1. **Resolve connection** – the API looks up the conversation to find the
    bound database connection and recent messages.
-2. **Generate query** – context and schema are sent to the LLM to obtain an
-   SQL statement and chart plan.
-3. **Execute SQL** – the generated query runs against the conversation’s
-   database and returns rows.
-4. **Summarize results** – rows are fed back to the LLM to craft a chart and
-   natural‑language summary, which are saved as an assistant message.
-5. **Respond to user** – the API returns the chart suggestion to the client.
+2. **Run workflow** – the LangGraph workflow uses the prompt and context to
+   analyze data and generate an assistant reply with a chart specification.
+3. **Persist response** – the assistant output is stored as a message.
+4. **Respond to user** – the API returns the response and chart spec to the client.
 
 ### AI workflow steps
 

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -7,7 +7,10 @@ from ....schemas import (
     ConversationDetail,
     ConversationListItem,
 )
-from ....services import conversation_service, llm_service
+import asyncio
+
+from ....services import conversation_service
+from ....workflows.ai_workflow import build_workflow, WorkflowState
 from ....auth import verify_token
 from ....config import settings
 
@@ -52,27 +55,39 @@ async def conversation_query(
     for msg in context["messages"]:
         text = msg["content"].get("text", "")
         history_parts.append(f"{msg['role']}: {text}")
-    history_parts.append(f"user: {request.prompt}")
-    full_prompt = "\n".join(history_parts)
+    history = "\n".join(history_parts)
 
     await conversation_service.add_message(
         conversation_id, "user", {"text": request.prompt}
     )
 
-    data = await llm_service.extract_data(
-        full_prompt, db_conn, request.model_name
+    db_url = (
+        f"postgresql://{db_conn.user}:{db_conn.password}@"
+        f"{db_conn.host}:{db_conn.port}/{db_conn.db_name}"
     )
-    charts = await llm_service.choose_charts(
-        full_prompt, request.available_charts, data, request.model_name
-    )
+
+    workflow = build_workflow()
+    state: WorkflowState = {
+        "conversation_id": conversation_id,
+        "prompt": request.prompt,
+        "history": history,
+        "db_url": db_url,
+    }
+    result = await asyncio.to_thread(workflow.invoke, state)
 
     await conversation_service.add_message(
         conversation_id,
         "assistant",
-        {"charts": [chart.model_dump() for chart in charts]},
+        {
+            "text": result.get("response"),
+            "chart_spec": result.get("chart_spec"),
+        },
     )
 
-    return QueryResponse(charts=charts)
+    return QueryResponse(
+        response=result.get("response", ""),
+        chart_spec=result.get("chart_spec"),
+    )
 
 
 @router.get("", response_model=list[ConversationListItem])

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -21,9 +21,10 @@ class ConversationQueryRequest(BaseModel):
 
 
 class QueryResponse(BaseModel):
-    """Response payload containing chart suggestions and data."""
+    """Response payload containing the assistant reply and chart spec."""
 
-    charts: List[ChartData]
+    response: str
+    chart_spec: Dict[str, Any] | None = None
 
 
 class ConversationCreateRequest(BaseModel):


### PR DESCRIPTION
## Summary
- Replace direct LLM service calls in conversation query route with LangGraph workflow execution
- Introduce workflow-driven API response returning assistant reply and chart specification
- Document workflow-based conversations endpoint in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a437887d2483238bbb053727cbc0da