### PR TITLE
Refactor conversation query to use LangGraph workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,19 +69,21 @@ JWT cookie unless noted.
 - `GET /conversations` – list conversations for the current user
 - `GET /conversations/{id}` – fetch a conversation with its messages
 - `POST /conversations` – create a conversation bound to a DB connection
-- `POST /conversations/{id}/query` – send a prompt and receive chart data. If
+- `POST /conversations/{id}/query` – send a prompt and run the AI workflow. If
   clarification is needed, the response includes `needs_clarification` and a
-  list of `clarification_questions`. Answer them using the
-  `clarification_answers` field in a follow-up request.
+  list of `clarification_questions`. Otherwise the payload contains the
+  workflow's `response` text and a `chart_spec` object for rendering. Simply
+  reply with another prompt to answer any clarification questions.
 
 ## Backend workflow
 
 Each conversation stores the database connection it should use. When a user
 sends a query, the API fetches the associated connection, gathers recent
 messages for context, and checks whether more details are needed. If so, it
-returns clarification questions before running any SQL. Otherwise it calls the
-LLM to produce chart-ready data. The resulting chart suggestions are saved as
-assistant messages. After each assistant response, the conversation is
+returns clarification questions before running any SQL. Otherwise it executes
+the LangGraph workflow to produce an assistant `response` and `chart_spec`.
+The resulting specification is saved as an assistant message. After each
+assistant response, the conversation is
 summarized and stored so later requests only need the summary plus the most
 recent messages.
 
@@ -90,9 +92,9 @@ flowchart LR
     U[User] -->|query| API
     API -->|lookup| DB[(PostgreSQL)]
     API -->|prompt + data| LLM
-    LLM -->|charts| API
+    LLM -->|analysis| API
     API -->|assistant message| DB
-    API -->|response| U
+    API -->|response + chart spec| U
 ```
 
 ### Detailed request flow
@@ -114,7 +116,7 @@ sequenceDiagram
     API->>LLM: Summarize rows into chart data
     LLM-->>API: Chart spec + summary
     API->>DB: Persist assistant response
-    API-->>U: Return chart suggestion
+    API-->>U: Return response + chart spec
 ```
 
 1. **Resolve connection** – the API looks up the conversation to find the
@@ -123,9 +125,11 @@ sequenceDiagram
    SQL statement and chart plan.
 3. **Execute SQL** – the generated query runs against the conversation’s
    database and returns rows.
-4. **Summarize results** – rows are fed back to the LLM to craft a chart and
-   natural‑language summary, which are saved as an assistant message.
-5. **Respond to user** – the API returns the chart suggestion to the client.
+4. **Summarize results** – rows are fed back to the LLM to craft a chart
+   specification and natural‑language summary, which are saved as an assistant
+   message.
+5. **Respond to user** – the API returns the generated response and chart
+   specification to the client.
 
 ### AI workflow steps
 

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import APIRouter, HTTPException, Depends
 from ....schemas import (
     ConversationCreateRequest,
@@ -7,8 +9,9 @@ from ....schemas import (
     ConversationDetail,
     ConversationListItem,
 )
-from ....services import conversation_service, llm_service
-from ....workflows.ai_workflow import intent_understanding, clarification
+from ....services import conversation_service
+from ....workflows import build_workflow
+from ....workflows.ai_workflow import WorkflowState
 from ....auth import verify_token
 from ....config import settings
 
@@ -53,39 +56,46 @@ async def conversation_query(
     for msg in context["messages"]:
         text = msg["content"].get("text", "")
         history_parts.append(f"{msg['role']}: {text}")
-    history_parts.append(f"user: {request.prompt}")
-    full_prompt = "\n".join(history_parts)
+    history = "\n".join(history_parts)
 
     await conversation_service.add_message(
         conversation_id, "user", {"text": request.prompt}
     )
 
-    state = {"prompt": request.prompt}
-    if request.clarification_answers:
-        state["clarification_answers"] = request.clarification_answers
-    state = intent_understanding(state)
-    state = clarification(state)
+    dsn = (
+        f"postgresql://{db_conn.user}:{db_conn.password}"
+        f"@{db_conn.host}:{db_conn.port}/{db_conn.db_name}"
+    )
+    state: WorkflowState = {
+        "conversation_id": conversation_id,
+        "prompt": request.prompt,
+        "history": history,
+        "db_url": dsn,
+        "available_charts": request.available_charts,
+        "model_name": request.model_name,
+    }
+
+    workflow = build_workflow()
+    state = await asyncio.to_thread(workflow.invoke, state)
+
     if state.get("needs_clarification"):
         return QueryResponse(
-            charts=[],
             needs_clarification=True,
             clarification_questions=state.get("clarification_questions", []),
         )
 
-    data = await llm_service.extract_data(
-        full_prompt, db_conn, request.model_name
-    )
-    charts = await llm_service.choose_charts(
-        full_prompt, request.available_charts, data, request.model_name
-    )
-
     await conversation_service.add_message(
         conversation_id,
         "assistant",
-        {"charts": [chart.model_dump() for chart in charts]},
+        {
+            "response": state.get("response"),
+            "chart_spec": state.get("chart_spec"),
+        },
     )
 
-    return QueryResponse(charts=charts)
+    return QueryResponse(
+        response=state.get("response"), chart_spec=state.get("chart_spec")
+    )
 
 
 @router.get("", response_model=list[ConversationListItem])

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -18,13 +18,12 @@ class ConversationQueryRequest(BaseModel):
     prompt: str
     available_charts: List[str]
     model_name: str
-    clarification_answers: Optional[Dict[str, Any]] = None
 
 
 class QueryResponse(BaseModel):
-    """Response payload containing chart suggestions and data."""
-
-    charts: List[ChartData]
+    """Response payload from the workflow."""
+    response: Optional[str] = None
+    chart_spec: Optional[Dict[str, Any]] = None
     needs_clarification: bool = False
     clarification_questions: Optional[List[str]] = None
 

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -53,6 +53,8 @@ class WorkflowState(TypedDict, total=False):
     timeframe: str
     timezone: str
     currency: str
+    available_charts: List[str]
+    model_name: str
 
 
 def prompt_intake(state: WorkflowState) -> WorkflowState:
@@ -67,6 +69,7 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
     logger.info("Step 2: Intent & query understanding")
 
     prompt = state.get("prompt", "")
+    history = state.get("history", "")
     client = OpenAI(api_key=settings.LLM_API_KEY)
     response_format = {
         "type": "json_schema",
@@ -98,7 +101,7 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
     message = (
         "Determine the user's intent (analysis or advice) and extract any metrics, "
         "dimensions, and timeframe mentioned.\n"
-        f"User request: {prompt}"
+        f"Conversation so far:\n{history}\nUser request: {prompt}"
     )
     try:
         resp = client.responses.create(


### PR DESCRIPTION
## Summary
- drop `clarification_answers` in favor of a single prompt and let the workflow decide if more info is needed
- pass `available_charts` and `model_name` into the workflow state and consider conversation history when extracting intent
- document clarification handling via follow-up prompts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a45f9be85c8323993741c6e82c6365