### PR TITLE
Move history gathering into prompt intake step

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ JWT cookie unless noted.
 ## Backend workflow
 
 Each conversation stores the database connection it should use. When a user
-sends a query, the API fetches the associated connection, gathers recent
-messages for context, and checks whether more details are needed. If so, it
-returns clarification questions before running any SQL. Otherwise it executes
-the LangGraph workflow to produce an assistant `response` and `chart_spec`.
+sends a query, the API fetches the associated connection and records the prompt.
+The workflow's prompt intake step then gathers recent messages for context and
+checks whether more details are needed. If so, it returns clarification
+questions before running any SQL. Otherwise it executes the LangGraph workflow
+to produce an assistant `response` and `chart_spec`.
 The resulting specification is saved as an assistant message. After each
 assistant response, the conversation is
 summarized and stored so later requests only need the summary plus the most

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -47,17 +47,6 @@ async def conversation_query(
         detail = str(exc)
         status = 400 if detail == "DB connection disabled" else 404
         raise HTTPException(status_code=status, detail=detail)
-    context = await conversation_service.get_context(
-        conversation_id, token_data["user_id"]
-    )
-    history_parts = []
-    if context.get("summary"):
-        history_parts.append(context["summary"])
-    for msg in context["messages"]:
-        text = msg["content"].get("text", "")
-        history_parts.append(f"{msg['role']}: {text}")
-    history = "\n".join(history_parts)
-
     await conversation_service.add_message(
         conversation_id, "user", {"text": request.prompt}
     )
@@ -68,8 +57,8 @@ async def conversation_query(
     )
     state: WorkflowState = {
         "conversation_id": conversation_id,
+        "user_id": token_data["user_id"],
         "prompt": request.prompt,
-        "history": history,
         "db_url": dsn,
         "available_charts": request.available_charts,
         "model_name": request.model_name,

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -34,6 +34,7 @@ class WorkflowState(TypedDict, total=False):
     """Shared state passed between workflow nodes."""
 
     conversation_id: str
+    user_id: str
     prompt: str
     history: str
     intent: str
@@ -61,7 +62,36 @@ class WorkflowState(TypedDict, total=False):
 def prompt_intake(state: WorkflowState) -> WorkflowState:
     """Receive the user prompt and load conversation history."""
     logger.info("Step 1: Prompt intake for conversation %s", state.get("conversation_id"))
-    state.setdefault("history", "")
+    conv_id = state.get("conversation_id")
+    user_id = state.get("user_id")
+    if conv_id and user_id:
+        try:
+            try:
+                context = asyncio.run(
+                    conversation_service.get_context(conv_id, user_id)
+                )
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+                context = loop.run_until_complete(
+                    conversation_service.get_context(conv_id, user_id)
+                )
+            messages = context.get("messages", [])
+            if messages and messages[-1].get("role") == "user":
+                messages = messages[:-1]
+            history_parts = []
+            if context.get("summary"):
+                history_parts.append(context["summary"])
+            for msg in messages:
+                text = msg["content"].get("text", "")
+                history_parts.append(f"{msg['role']}: {text}")
+            state["history"] = "\n".join(history_parts)
+        except Exception:
+            logger.exception(
+                "Failed to load conversation history for %s", conv_id
+            )
+            state["history"] = ""
+    else:
+        state.setdefault("history", "")
     return state
 
 


### PR DESCRIPTION
## Summary
- Gather conversation history inside `prompt_intake` workflow step
- Simplify conversation query route to pass user id and prompt only
- Document that workflow now loads history during prompt intake

## Testing
- `pytest --ignore=server/.venv`

------
https://chatgpt.com/codex/tasks/task_e_68a52c125f1083239e10b06ce9708785