### PR TITLE
Refactor message schema and query response

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,27 @@ JWT cookie unless noted.
 - `GET /conversations/{id}` – fetch a conversation with its messages
 - `POST /conversations` – create a conversation bound to a DB connection
 - `POST /conversations/{id}/query` – send a prompt and run the AI workflow. The
-  payload contains a `response` string and an optional `chart_spec` object for
-  rendering. If the workflow needs more details, follow-up questions are
-  returned in the `response` field; simply answer them with another prompt.
+  response uses a standard envelope with `status`, `code`, and a `data.message`
+  array of parts. Each part is either `{ "type": "text" }` or `{ "type":
+  "data" }` for chart specifications. If the workflow needs more details,
+  follow-up questions are returned as text parts.
 
 #### Response schema
 
 ```json
 {
-  "response": "Answer text or clarifying questions",
-  "chart_spec": { }
+  "status": "ok",
+  "code": 200,
+  "data": {
+    "message": [
+      { "type": "text", "content": "Answer text or clarifying questions" },
+      { "type": "data", "content": { } }
+    ]
+  }
 }
 ```
 
-Clarifications are included directly in `response`. The API does not split
+Clarifications are included as additional text parts. The API does not split
 prompts containing multiple questions, so the front end should either prompt the
 user for a single question or issue multiple calls.
 
@@ -218,6 +225,7 @@ erDiagram
     USER ||--o{ CONVERSATION : starts
     DB_CONNECTION ||--o{ CONVERSATION : "selected for"
     CONVERSATION ||--o{ MESSAGE : has
+    MESSAGE ||--o{ MESSAGE_CONTENT : includes
     %% CONVERSATION ||--o{ CONVO_SUMMARY : summarizes
     CONVERSATION ||--o{ CONVERSATION_CHECKPOINT : memorizes
 
@@ -254,10 +262,14 @@ erDiagram
     MESSAGE {
         uuid id PK
         uuid conversation_id FK
-        string role
-        json content
-        int token_count
+        string author
         timestamp created_at
+    }
+    MESSAGE_CONTENT {
+        uuid id PK
+        uuid message_id FK
+        string type
+        json content
     }
     %% CONVO_SUMMARY {
     %%     uuid id PK

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -6,9 +6,15 @@ export type DBConnection = {
   port: number
 }
 
+export type MessageContent =
+  | { type: 'text'; content: string }
+  | { type: 'data'; content: Record<string, unknown> }
+
 export type QueryResponse = {
-  response?: string | null
-  chart_spec?: Record<string, unknown> | null
+  status: string
+  code: number
+  data: { message: MessageContent[] }
+  error?: string
 }
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000'
@@ -100,7 +106,7 @@ export async function getConversation(id: string) {
   return fetchJson<{
     id: string
     title: string | null
-    messages: { id: string; role: string; content: unknown }[]
+    messages: { id: string; author: string; contents: MessageContent[] }[]
   }>(`${API_BASE}/conversations/${id}`, {
     credentials: 'include',
   })

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -24,19 +24,24 @@ import {
   createConversation,
   conversationQuery,
   getConversation,
+  MessageContent,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
-export type Message = { id: string; role: 'user' | 'assistant'; content: string; pending?: boolean }
+export type Message = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  pending?: boolean
+}
 
 type Props = { user: { id: string; username: string } }
 type DBConnItem = { id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }
 
-function formatContent(content: { text?: string; response?: string; chart_spec?: Record<string, unknown> }): string {
-  if (content?.text) return content.text
-  if (content?.response) return content.response
-  if (content?.chart_spec) return JSON.stringify(content.chart_spec, null, 2)
-  return JSON.stringify(content)
+function formatMessageContents(contents: MessageContent[]): string {
+  return contents
+    .map((c) => (c.type === 'text' ? c.content : JSON.stringify(c.content, null, 2)))
+    .join('\n')
 }
 
 function ChatBubble({ message }: { message: Message }) {
@@ -148,7 +153,7 @@ export default function Chat({ user }: Props) {
         available_charts: ['bar', 'line', 'pie'],
         model_name: 'gpt-4o-mini',
       })
-      const assistantText = formatContent({ response: res.response, chart_spec: res.chart_spec })
+      const assistantText = formatMessageContents(res.data.message)
       setMessagesMap((prev) => ({
         ...prev,
         [convoId!]: prev[convoId!].map((m) =>
@@ -227,12 +232,8 @@ export default function Chat({ user }: Props) {
           ...prev,
           [id]: convo.messages.map((m) => ({
             id: m.id,
-            role: m.role as 'user' | 'assistant',
-            content: formatContent(m.content as {
-              text?: string
-              response?: string
-              chart_spec?: Record<string, unknown>
-            }),
+            role: m.author === 'assistant' ? 'assistant' : 'user',
+            content: formatMessageContents(m.contents),
           })),
         }))
       } catch (err) {

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -49,7 +49,9 @@ async def conversation_query(
         status = 400 if detail == "DB connection disabled" else 404
         raise HTTPException(status_code=status, detail=detail)
     await conversation_service.add_message(
-        conversation_id, "user", {"text": request.prompt}
+        conversation_id,
+        token_data["user_id"],
+        [{"type": "text", "content": request.prompt}],
     )
 
     dsn = (
@@ -75,17 +77,20 @@ async def conversation_query(
         questions = state.get("clarification_questions", [])
         response_text = "\n".join(questions)
 
+    assistant_contents = [{"type": "text", "content": response_text or ""}]
+    if state.get("chart_spec"):
+        assistant_contents.append({"type": "data", "content": state.get("chart_spec")})
+
     await conversation_service.add_message(
         conversation_id,
         "assistant",
-        {
-            "response": response_text,
-            "chart_spec": state.get("chart_spec"),
-        },
+        assistant_contents,
     )
 
     result = QueryResponse(
-        response=response_text, chart_spec=state.get("chart_spec")
+        status="ok",
+        code=200,
+        data={"message": assistant_contents},
     )
 
     # Update conversation memory

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -46,13 +46,18 @@ CREATE TABLE IF NOT EXISTS conversation (
 CREATE TABLE IF NOT EXISTS message (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   conversation_id UUID NOT NULL REFERENCES conversation(id) ON DELETE CASCADE,
-  role VARCHAR(50) NOT NULL CHECK (role IN ('user','assistant','system','tool')),
-  content JSONB NOT NULL,
-  token_count INT,
-  created_at TIMESTAMPTZ DEFAULT now(),
-  parent_id UUID REFERENCES message(id)
+  author VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS idx_message_convo_created ON message (conversation_id, created_at);
+
+CREATE TABLE IF NOT EXISTS message_content (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id UUID NOT NULL REFERENCES message(id) ON DELETE CASCADE,
+  type VARCHAR(50) NOT NULL CHECK (type IN ('text','data')),
+  content JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_message_content_msg ON message_content (message_id, id);
 
 -- CREATE TABLE IF NOT EXISTS convo_summary (
 --   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Literal
 
 from pydantic import BaseModel
 
@@ -20,10 +20,24 @@ class ConversationQueryRequest(BaseModel):
     model_name: str
 
 
+class MessageContent(BaseModel):
+    """Single message component."""
+
+    type: Literal["text", "data"]
+    content: Any
+
+
+class QueryResponseData(BaseModel):
+    message: List[MessageContent]
+
+
 class QueryResponse(BaseModel):
-    """Response payload from the workflow."""
-    response: Optional[str] = None
-    chart_spec: Optional[Dict[str, Any]] = None
+    """Standardized API response."""
+
+    status: str
+    code: int
+    data: QueryResponseData
+    error: Optional[str] = None
 
 
 class ConversationCreateRequest(BaseModel):
@@ -48,8 +62,8 @@ class ConversationListItem(BaseModel):
 
 class MessageItem(BaseModel):
     id: str
-    role: str
-    content: Dict[str, Any]
+    author: str
+    contents: List[MessageContent]
 
 
 class ConversationDetail(BaseModel):

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -1,10 +1,7 @@
 # import asyncio
 import json
 import logging
-# from collections import Counter
-from typing import Any, Dict, Optional, Tuple
-
-# from openai import OpenAI
+from typing import Any, Dict, Optional, Tuple, List
 
 from ..config import settings
 from ..db.database import get_pool
@@ -12,19 +9,6 @@ from ..schemas.db_connection import DBConnection
 
 
 logger = logging.getLogger(__name__)
-# _summary_failures: Counter[str] = Counter()
-
-
-def _estimate_tokens_from_text(text: str) -> int:
-    """Rough token estimator based on whitespace splitting."""
-    return max(1, len(text.split()))
-
-
-def _estimate_tokens_from_content(content: Dict[str, Any]) -> int:
-    text = content.get("text") if isinstance(content, dict) else None
-    if not text:
-        text = json.dumps(content)
-    return _estimate_tokens_from_text(text)
 
 
 async def create_conversation(
@@ -80,36 +64,36 @@ async def get_conversation_db_connection(
 
 async def add_message(
     conversation_id: str,
-    role: str,
-    content: Dict[str, Any],
-    token_count: Optional[int] = None,
-    parent_id: Optional[str] = None,
+    author: str,
+    contents: List[Dict[str, Any]],
 ) -> str:
     """Persist a message and return its id."""
-    if token_count is None:
-        token_count = _estimate_tokens_from_content(content)
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
             row = await conn.fetchrow(
                 """
-                INSERT INTO message (conversation_id, role, content, token_count, parent_id)
-                VALUES ($1, $2, $3, $4, $5) RETURNING id
+                INSERT INTO message (conversation_id, author) VALUES ($1, $2) RETURNING id
                 """,
                 conversation_id,
-                role,
-                json.dumps(content),
-                token_count,
-                parent_id,
+                author,
             )
+            message_id = row["id"]
+            for c in contents:
+                await conn.execute(
+                    """
+                    INSERT INTO message_content (message_id, type, content)
+                    VALUES ($1, $2, $3)
+                    """,
+                    message_id,
+                    c["type"],
+                    json.dumps(c["content"]),
+                )
             await conn.execute(
                 "UPDATE conversation SET updated_at=now() WHERE id=$1",
                 conversation_id,
             )
-    message_id = str(row["id"])
-    # if role == "assistant":
-    #     asyncio.create_task(summarize_conversation(conversation_id))
-    return message_id
+    return str(message_id)
 
 
 # async def summarize_conversation(
@@ -294,19 +278,23 @@ async def get_conversation(conversation_id: str, user_id: str) -> Dict[str, Any]
         if not convo:
             raise ValueError("Conversation not found")
         rows = await conn.fetch(
-            """SELECT id, role, content FROM message
-            WHERE conversation_id=$1 ORDER BY created_at""",
+            """
+            SELECT m.id as message_id, m.author, mc.type, mc.content
+            FROM message m
+            JOIN message_content mc ON mc.message_id = m.id
+            WHERE m.conversation_id=$1
+            ORDER BY m.created_at, mc.id
+            """,
             conversation_id,
         )
+    messages: Dict[str, Dict[str, Any]] = {}
+    for r in rows:
+        mid = str(r["message_id"])
+        if mid not in messages:
+            messages[mid] = {"id": mid, "author": r["author"], "contents": []}
+        messages[mid]["contents"].append({"type": r["type"], "content": r["content"]})
     return {
         "id": str(convo["id"]),
         "title": convo["title"],
-        "messages": [
-            {
-                "id": str(r["id"]),
-                "role": r["role"],
-                "content": r["content"],
-            }
-            for r in rows
-        ],
+        "messages": list(messages.values()),
     }


### PR DESCRIPTION
## Summary
- standardize QueryResponse with status, code and multi-part message payload
- split messages into `message` and `message_content` tables with author tracking
- update conversation service, API route and front-end types to handle structured message parts
- document new response envelope and schema

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a884bdd5c083239271fdbd262a625c