### PR TITLE
feat: structure chart specification schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,24 @@ JWT cookie unless noted.
 }
 ```
 
+Chart specifications returned in `data` parts follow this schema:
+
+```json
+{
+  "title": "string",
+  "xAxis": {
+    "label": "string",
+    "dataType": "category" | "date" | "numeric",
+    "values": ["string" | number],
+    "unit": "string (optional)"
+  },
+  "yAxis": [
+    { "label": "string", "values": [number], "unit": "string (optional)" }
+  ],
+  "chartTypes": ["string"]
+}
+```
+
 Clarifications are included as additional text parts. The API does not split
 prompts containing multiple questions, so the front end should either prompt the
 user for a single question or issue multiple calls.

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -6,9 +6,29 @@ export type DBConnection = {
   port: number
 }
 
+export type XAxisSpec = {
+  label: string
+  dataType: 'category' | 'date' | 'numeric'
+  values: (string | number)[]
+  unit?: string
+}
+
+export type YAxisSpec = {
+  label: string
+  values: number[]
+  unit?: string
+}
+
+export type ChartSpecification = {
+  title: string
+  xAxis: XAxisSpec
+  yAxis: YAxisSpec[]
+  chartTypes: string[]
+}
+
 export type MessageContent =
   | { type: 'text'; content: string }
-  | { type: 'data'; content: Record<string, unknown> }
+  | { type: 'data'; content: ChartSpecification }
 
 export type QueryResponse = {
   status: string

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal, Union
 
 from pydantic import BaseModel
 
@@ -20,11 +20,43 @@ class ConversationQueryRequest(BaseModel):
     model_name: str
 
 
-class MessageContent(BaseModel):
-    """Single message component."""
+class XAxisSpec(BaseModel):
+    """Metadata for the X axis of a chart."""
 
-    type: Literal["text", "data"]
-    content: Any
+    label: str
+    dataType: Literal["category", "date", "numeric"]
+    values: List[Union[str, int, float]]
+    unit: Optional[str] = None
+
+
+class YAxisSpec(BaseModel):
+    """Metadata for a Y axis series."""
+
+    label: str
+    values: List[float]
+    unit: Optional[str] = None
+
+
+class ChartSpecification(BaseModel):
+    """Schema describing chartable data."""
+
+    title: str
+    xAxis: XAxisSpec
+    yAxis: List[YAxisSpec]
+    chartTypes: List[str]
+
+
+class TextContent(BaseModel):
+    type: Literal["text"]
+    content: str
+
+
+class DataContent(BaseModel):
+    type: Literal["data"]
+    content: ChartSpecification
+
+
+MessageContent = Union[TextContent, DataContent]
 
 
 class QueryResponseData(BaseModel):

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -314,15 +314,8 @@ def visualization_spec(state: WorkflowState) -> WorkflowState:
     else:
         chart_type = "bar"
 
-    # Scales for React charting library
-    scales = {
-        "x": {"type": "time" if time_like else "band"},
-        "y": {"type": "linear"},
-    }
-
-    # Labels and metadata
+    # Build new chart specification schema
     x_label = dims[0] if dims else ""
-    y_label = measures[0] if measures else ""
     title_parts: List[str] = []
     if measures:
         title_parts.append(", ".join(measures))
@@ -330,22 +323,32 @@ def visualization_spec(state: WorkflowState) -> WorkflowState:
         title_parts.append("by " + ", ".join(dims))
     title = " ".join(title_parts) if title_parts else "Chart"
 
-    labels: Dict[str, str] = {"title": title, "x": x_label, "y": y_label}
-    if len(dims) > 1:
-        labels["color"] = dims[1]
+    x_values = [row.get(x_label) for row in data] if x_label else []
+    data_type = "category"
+    if x_values:
+        first = x_values[0]
+        if isinstance(first, (int, float)):
+            data_type = "numeric"
+        elif isinstance(first, str) and re.match(r"\d{4}-\d{2}-\d{2}", first):
+            data_type = "date"
 
-    # Simple color palette
-    colors = ["#5B8FF9", "#5AD8A6", "#5D7092", "#F6BD16"]
+    y_axes: List[Dict[str, Any]] = []
+    for m in measures:
+        values = [float(row.get(m, 0)) for row in data]
+        y_axes.append({"label": m, "values": values})
 
-    state["chart_spec"] = {
-        "chart_type": chart_type,
-        "data": data,
-        "dimensions": dims,
-        "measures": measures,
-        "scales": scales,
-        "labels": labels,
-        "colors": colors,
+    chart_spec = {
+        "title": title,
+        "xAxis": {
+            "label": x_label,
+            "dataType": data_type,
+            "values": x_values,
+        },
+        "yAxis": y_axes,
+        "chartTypes": [chart_type],
     }
+
+    state["chart_spec"] = chart_spec
     return state
 
 


### PR DESCRIPTION
## Summary
- define ChartSpecification and related models for API message contents
- emit chart specs in new {title, xAxis, yAxis, chartTypes} format
- document chart spec schema and expose types to the frontend

## Testing
- `cd server && uv run pytest`
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab11c9c2a483238ecf73145cfbab71