### PR TITLE
Add created_at timestamp to message_content

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ erDiagram
         uuid message_id FK
         string type
         json content
+        timestamp created_at
     }
     %% CONVO_SUMMARY {
     %%     uuid id PK

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -55,7 +55,8 @@ CREATE TABLE IF NOT EXISTS message_content (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   message_id UUID NOT NULL REFERENCES message(id) ON DELETE CASCADE,
   type VARCHAR(50) NOT NULL CHECK (type IN ('text','data')),
-  content JSONB NOT NULL
+  content JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS idx_message_content_msg ON message_content (message_id, id);
 


### PR DESCRIPTION
## Summary
- track when individual message content entries are created
- document message_content created_at field in data model

## Testing
- `uv run pytest`
- `uv run ruff check` *(fails: unused imports)*

------
https://chatgpt.com/codex/tasks/task_e_68abbb936a688323a853b7cf5688594a