### PR TITLE
feat: add user reference to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ erDiagram
         uuid id PK
         uuid conversation_id FK
         string author
+        uuid user_id FK
         timestamp created_at
     }
     MESSAGE_CONTENT {

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -50,8 +50,9 @@ async def conversation_query(
         raise HTTPException(status_code=status, detail=detail)
     await conversation_service.add_message(
         conversation_id,
-        token_data["user_id"],
+        "user",
         [{"type": "text", "content": request.prompt}],
+        token_data["user_id"],
     )
 
     dsn = (

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS message (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   conversation_id UUID NOT NULL REFERENCES conversation(id) ON DELETE CASCADE,
   author VARCHAR(255) NOT NULL,
+  user_id UUID REFERENCES app_user(id),
   created_at TIMESTAMPTZ DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS idx_message_convo_created ON message (conversation_id, created_at);

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -95,6 +95,7 @@ class ConversationListItem(BaseModel):
 class MessageItem(BaseModel):
     id: str
     author: str
+    user_id: Optional[str] = None
     contents: List[MessageContent]
 
 

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -66,17 +66,23 @@ async def add_message(
     conversation_id: str,
     author: str,
     contents: List[Dict[str, Any]],
+    user_id: Optional[str] = None,
 ) -> str:
     """Persist a message and return its id."""
+    if author == "user" and user_id is None:
+        raise ValueError("user_id must be provided when author is 'user'")
+    if author != "user":
+        user_id = None
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
             row = await conn.fetchrow(
                 """
-                INSERT INTO message (conversation_id, author) VALUES ($1, $2) RETURNING id
+                INSERT INTO message (conversation_id, author, user_id) VALUES ($1, $2, $3) RETURNING id
                 """,
                 conversation_id,
                 author,
+                user_id,
             )
             message_id = row["id"]
             for c in contents:
@@ -284,7 +290,7 @@ async def get_conversation(conversation_id: str, user_id: str) -> Dict[str, Any]
             raise ValueError("Conversation not found")
         rows = await conn.fetch(
             """
-            SELECT m.id as message_id, m.author, mc.type, mc.content
+            SELECT m.id as message_id, m.author, m.user_id, mc.type, mc.content
             FROM message m
             JOIN message_content mc ON mc.message_id = m.id
             WHERE m.conversation_id=$1
@@ -296,7 +302,12 @@ async def get_conversation(conversation_id: str, user_id: str) -> Dict[str, Any]
     for r in rows:
         mid = str(r["message_id"])
         if mid not in messages:
-            messages[mid] = {"id": mid, "author": r["author"], "contents": []}
+            messages[mid] = {
+                "id": mid,
+                "author": r["author"],
+                "user_id": str(r["user_id"]) if r["user_id"] else None,
+                "contents": [],
+            }
         messages[mid]["contents"].append({"type": r["type"], "content": r["content"]})
     return {
         "id": str(convo["id"]),


### PR DESCRIPTION
## Summary
- add optional `user_id` foreign key to messages table
- require user id when persisting user messages and expose it in conversation details
- document message `user_id` field in README

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abbd9374848323b767977bde6a6392