### PR TITLE
refactor chat page with hooks and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ React + Vite front end and a FastAPI backend.
 - Toggleable sidebar for switching conversations and configuring connections, fetching conversations on mount
 - <!-- Conversations are summarized after each assistant reply using an LLM to keep
   context within token limits, and each summary records its last refresh time -->
+- Chat UI built with reusable layout and custom hooks for conversations and messages
 - Conversation history is stored via a LangGraph checkpointer backed by
   PostgreSQL, which keeps the latest K messages and summarizes older ones
 - Inline error messages with cleared loading indicators for failed API calls

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  sidebar: ReactNode
+  children: ReactNode
+}
+
+export function AppLayout({ sidebar, children }: Props) {
+  const [open, setOpen] = useState(true)
+  return (
+    <div className="flex h-dvh w-full">
+      <div className={cn('border-r overflow-y-auto transition-all', open ? 'w-64' : 'w-0')}>
+        <div className={cn('p-2', open ? 'block' : 'hidden')}>{sidebar}</div>
+      </div>
+      <div className="flex flex-1 flex-col relative">
+        <Button
+          variant="outline"
+          size="sm"
+          className="absolute top-2 left-2 z-10 h-8 w-8 p-0"
+          onClick={() => setOpen((o) => !o)}
+        >
+          {open ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </Button>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/ChatBubble.tsx
+++ b/client/src/components/ChatBubble.tsx
@@ -1,0 +1,39 @@
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { cn } from '@/lib/utils'
+import type { Message } from '@/lib/types'
+
+export function ChatBubble({ message }: { message: Message }) {
+  const isUser = message.role === 'user'
+  return (
+    <div className={cn('flex w-full gap-3', isUser ? 'justify-end' : 'justify-start')}>
+      {!isUser && (
+        <Avatar className="h-8 w-8">
+          <AvatarFallback>AI</AvatarFallback>
+        </Avatar>
+      )}
+      <div
+        className={cn(
+          'max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm',
+          isUser
+            ? 'bg-primary text-primary-foreground rounded-br-sm'
+            : 'bg-secondary text-secondary-foreground rounded-bl-sm'
+        )}
+      >
+        {message.pending ? (
+          <span className="inline-flex items-center gap-1 opacity-70">
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.2s]"></span>
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.1s]"></span>
+            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current"></span>
+          </span>
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
+        )}
+      </div>
+      {isUser && (
+        <Avatar className="h-8 w-8">
+          <AvatarFallback>U</AvatarFallback>
+        </Avatar>
+      )}
+    </div>
+  )
+}

--- a/client/src/hooks/useConversations.ts
+++ b/client/src/hooks/useConversations.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import { getConversations, getConversation } from '@/lib/api'
+import type { Conversation, Message } from '@/lib/types'
+import { formatMessageContents } from '@/lib/utils'
+
+export function useConversations() {
+  const [convos, setConvos] = useState<Conversation[]>([])
+  const [currentConvo, setCurrentConvo] = useState<string | null>(null)
+  const [messagesMap, setMessagesMap] = useState<Record<string, Message[]>>({})
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getConversations()
+      .then(setConvos)
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : 'Failed to load conversations')
+      )
+  }, [])
+
+  const selectConvo = async (id: string) => {
+    setCurrentConvo(id)
+    if (!messagesMap[id]) {
+      try {
+        const convo = await getConversation(id)
+        setMessagesMap((prev) => ({
+          ...prev,
+          [id]: convo.messages.map((m) => ({
+            id: m.id,
+            role: m.author === 'assistant' ? 'assistant' : 'user',
+            content: formatMessageContents(m.contents),
+          })),
+        }))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load conversation')
+      }
+    }
+  }
+
+  return {
+    convos,
+    setConvos,
+    currentConvo,
+    setCurrentConvo,
+    selectConvo,
+    messagesMap,
+    setMessagesMap,
+    error,
+    setError,
+  }
+}

--- a/client/src/hooks/useMessages.ts
+++ b/client/src/hooks/useMessages.ts
@@ -1,0 +1,92 @@
+import { useRef, useEffect, useState } from 'react'
+import { conversationQuery, createConversation } from '@/lib/api'
+import type { Message, User, Conversation } from '@/lib/types'
+import { formatMessageContents } from '@/lib/utils'
+
+type Options = {
+  user: User
+  selectedConn?: string
+  currentConvo: string | null
+  setCurrentConvo: (id: string) => void
+  messagesMap: Record<string, Message[]>
+  setMessagesMap: React.Dispatch<React.SetStateAction<Record<string, Message[]>>>
+  setConvos: React.Dispatch<React.SetStateAction<Conversation[]>>
+}
+
+export function useMessages({
+  user,
+  selectedConn,
+  currentConvo,
+  setCurrentConvo,
+  messagesMap,
+  setMessagesMap,
+  setConvos,
+}: Options) {
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [messagesMap, currentConvo])
+
+  const messages = messagesMap[currentConvo ?? ''] || []
+
+  const handleSend = async () => {
+    const trimmed = input.trim()
+    if (!trimmed) return
+    setError(null)
+    setSending(true)
+    let convoId = currentConvo
+    let loadingId: string | undefined
+    try {
+      if (!convoId) {
+        if (!selectedConn) return
+        const { conversation_id } = await createConversation({
+          user_id: user.id,
+          db_connection_id: selectedConn,
+          title: trimmed.slice(0, 20),
+        })
+        convoId = conversation_id
+        setCurrentConvo(convoId)
+        setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
+      }
+      const id = crypto.randomUUID()
+      loadingId = crypto.randomUUID()
+      setMessagesMap((prev) => ({
+        ...prev,
+        [convoId!]: [
+          ...(prev[convoId!] || []),
+          { id, role: 'user', content: trimmed },
+          { id: loadingId!, role: 'assistant', content: '', pending: true },
+        ],
+      }))
+      setInput('')
+      const res = await conversationQuery(convoId!, {
+        prompt: trimmed,
+        available_charts: ['bar', 'line', 'pie'],
+        model_name: 'gpt-4o-mini',
+      })
+      const assistantText = formatMessageContents(res.data.message)
+      setMessagesMap((prev) => ({
+        ...prev,
+        [convoId!]: prev[convoId!].map((m) =>
+          m.id === loadingId ? { ...m, content: assistantText, pending: false } : m
+        ),
+      }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message')
+      if (convoId && loadingId) {
+        setMessagesMap((prev) => ({
+          ...prev,
+          [convoId!]: prev[convoId!].filter((m) => m.id !== loadingId),
+        }))
+      }
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return { messages, input, setInput, handleSend, sending, error, setError, bottomRef }
+}

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -1,0 +1,25 @@
+export type User = {
+  id: string
+  username: string
+}
+
+export type Message = {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  pending?: boolean
+}
+
+export type DBConnItem = {
+  id: string
+  db_name: string
+  host: string
+  port: number
+  user: string
+  enabled: boolean
+}
+
+export type Conversation = {
+  id: string
+  title: string | null
+}

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,13 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import type { MessageContent } from "./api"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function formatMessageContents(contents: MessageContent[]): string {
+  return contents
+    .map((c) => (c.type === "text" ? c.content : JSON.stringify(c.content, null, 2)))
+    .join("\n")
 }

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
 import {
   Dialog,
   DialogContent,
@@ -12,166 +18,72 @@ import {
   DialogClose,
 } from '@/components/ui/dialog'
 import { Separator } from '@/components/ui/separator'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
-import { Send, ChevronLeft, ChevronRight, Pencil } from 'lucide-react'
+import { Send, Pencil } from 'lucide-react'
 import {
   listDbConnections,
-  getConversations,
   createDbConnection,
   updateDbConnection,
   enableDbConnection,
   disableDbConnection,
-  createConversation,
-  conversationQuery,
-  getConversation,
-  MessageContent,
 } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { ChatBubble } from '@/components/ChatBubble'
+import { AppLayout } from '@/components/AppLayout'
+import { useConversations } from '@/hooks/useConversations'
+import { useMessages } from '@/hooks/useMessages'
+import type { DBConnItem, User } from '@/lib/types'
 
-export type Message = {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  pending?: boolean
-}
-
-type Props = { user: { id: string; username: string } }
-type DBConnItem = { id: string; db_name: string; host: string; port: number; user: string; enabled: boolean }
-
-function formatMessageContents(contents: MessageContent[]): string {
-  return contents
-    .map((c) => (c.type === 'text' ? c.content : JSON.stringify(c.content, null, 2)))
-    .join('\n')
-}
-
-function ChatBubble({ message }: { message: Message }) {
-  const isUser = message.role === 'user'
-  return (
-    <div className={cn('flex w-full gap-3', isUser ? 'justify-end' : 'justify-start')}>
-      {!isUser && (
-        <Avatar className="h-8 w-8">
-          <AvatarFallback>AI</AvatarFallback>
-        </Avatar>
-      )}
-      <div
-        className={cn(
-          'max-w-[80%] rounded-2xl px-3 py-2 text-sm shadow-sm',
-          isUser
-            ? 'bg-primary text-primary-foreground rounded-br-sm'
-            : 'bg-secondary text-secondary-foreground rounded-bl-sm'
-        )}
-      >
-        {message.pending ? (
-          <span className="inline-flex items-center gap-1 opacity-70">
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.2s]"></span>
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.1s]"></span>
-            <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current"></span>
-          </span>
-        ) : (
-          <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
-        )}
-      </div>
-      {isUser && (
-        <Avatar className="h-8 w-8">
-          <AvatarFallback>U</AvatarFallback>
-        </Avatar>
-      )}
-    </div>
-  )
-}
+type Props = { user: User }
 
 export default function Chat({ user }: Props) {
   const [dbConns, setDbConns] = useState<DBConnItem[]>([])
-  const [convos, setConvos] = useState<{ id: string; title: string | null }[]>([])
   const [selectedConn, setSelectedConn] = useState<string | undefined>()
   const [connOpen, setConnOpen] = useState(false)
   const [editingConn, setEditingConn] = useState<string | null>(null)
   const [connForm, setConnForm] = useState({ db_name: '', host: '', port: 5432, user: '', password: '' })
-  const [currentConvo, setCurrentConvo] = useState<string | null>(null)
-  const [messagesMap, setMessagesMap] = useState<Record<string, Message[]>>({})
-  const [input, setInput] = useState('')
-  const [sidebarOpen, setSidebarOpen] = useState(true)
-  const bottomRef = useRef<HTMLDivElement | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [sending, setSending] = useState(false)
   const [connLoading, setConnLoading] = useState(false)
+
+  const {
+    convos,
+    setConvos,
+    currentConvo,
+    setCurrentConvo,
+    selectConvo,
+    messagesMap,
+    setMessagesMap,
+    error,
+    setError,
+  } = useConversations()
+
+  const {
+    messages,
+    input,
+    setInput,
+    handleSend,
+    sending,
+    error: msgError,
+    setError: setMsgError,
+    bottomRef,
+  } = useMessages({
+    user,
+    selectedConn,
+    currentConvo,
+    setCurrentConvo,
+    messagesMap,
+    setMessagesMap,
+    setConvos,
+  })
 
   useEffect(() => {
     const load = async () => {
       try {
-        const [dbs, convs] = await Promise.all([
-          listDbConnections(),
-          getConversations(),
-        ])
-        setDbConns(dbs)
-        setConvos(convs)
+        setDbConns(await listDbConnections())
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load data')
       }
     }
     load()
-  }, [])
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
-  }, [messagesMap, currentConvo])
-
-  const messages = messagesMap[currentConvo ?? ''] || []
-
-  const handleSend = async () => {
-    const trimmed = input.trim()
-    if (!trimmed) return
-    setError(null)
-    setSending(true)
-    let convoId = currentConvo
-    let loadingId: string | undefined
-    try {
-      if (!convoId) {
-        if (!selectedConn) return
-        const { conversation_id } = await createConversation({
-          user_id: user.id,
-          db_connection_id: selectedConn,
-          title: trimmed.slice(0, 20),
-        })
-        convoId = conversation_id
-        setCurrentConvo(convoId)
-        setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
-      }
-      const id = crypto.randomUUID()
-      loadingId = crypto.randomUUID()
-      setMessagesMap((prev) => ({
-        ...prev,
-        [convoId!]: [
-          ...(prev[convoId!] || []),
-          { id, role: 'user', content: trimmed },
-          { id: loadingId, role: 'assistant', content: '', pending: true },
-        ],
-      }))
-      setInput('')
-      const res = await conversationQuery(convoId!, {
-        prompt: trimmed,
-        available_charts: ['bar', 'line', 'pie'],
-        model_name: 'gpt-4o-mini',
-      })
-      const assistantText = formatMessageContents(res.data.message)
-      setMessagesMap((prev) => ({
-        ...prev,
-        [convoId!]: prev[convoId!].map((m) =>
-          m.id === loadingId ? { ...m, content: assistantText, pending: false } : m
-        ),
-      }))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to send message')
-      if (convoId && loadingId) {
-        setMessagesMap((prev) => ({
-          ...prev,
-          [convoId!]: prev[convoId!].filter((m) => m.id !== loadingId),
-        }))
-      }
-    } finally {
-      setSending(false)
-    }
-  }
+  }, [setError])
 
   const refreshConns = async () => {
     try {
@@ -183,6 +95,7 @@ export default function Chat({ user }: Props) {
 
   const handleSaveConn = async () => {
     setError(null)
+    setMsgError(null)
     setConnLoading(true)
     const body = { ...connForm, user_id: user.id }
     try {
@@ -223,118 +136,92 @@ export default function Chat({ user }: Props) {
     setConnOpen(true)
   }
 
-  const handleSelectConvo = async (id: string) => {
-    setCurrentConvo(id)
-    if (!messagesMap[id]) {
-      try {
-        const convo = await getConversation(id)
-        setMessagesMap((prev) => ({
-          ...prev,
-          [id]: convo.messages.map((m) => ({
-            id: m.id,
-            role: m.author === 'assistant' ? 'assistant' : 'user',
-            content: formatMessageContents(m.contents),
-          })),
-        }))
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load conversation')
-      }
-    }
-  }
+  const sidebar = (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold">Connections</span>
+        <Button size="sm" onClick={openAddConn}>Add</Button>
+      </div>
+      {dbConns.map((c) => (
+        <div key={c.id} className="flex items-center justify-between text-sm">
+          <span>{c.db_name}</span>
+          <div className="flex gap-1">
+            <Button size="sm" variant="outline" onClick={() => handleToggleConn(c.id, c.enabled)}>
+              {c.enabled ? 'Disable' : 'Enable'}
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => openEditConn(c)}>
+              <Pencil className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+      ))}
+      <Separator className="my-2" />
+      <div className="space-y-1">
+        {convos.map((c) => (
+          <div
+            key={c.id}
+            className={cn('p-2 cursor-pointer', c.id === currentConvo && 'bg-accent')}
+            onClick={() => selectConvo(c.id)}
+          >
+            {c.title || 'Untitled'}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+
+  const allError = error || msgError
 
   return (
-    <div className="flex h-dvh w-full">
-      <div className={cn('border-r overflow-y-auto transition-all', sidebarOpen ? 'w-64' : 'w-0')}> 
-        <div className={cn('p-2 space-y-2', sidebarOpen ? 'block' : 'hidden')}>
-          <div className="flex items-center justify-between">
-            <span className="font-semibold">Connections</span>
-            <Button size="sm" onClick={openAddConn}>Add</Button>
-          </div>
-          {dbConns.map((c) => (
-            <div key={c.id} className="flex items-center justify-between text-sm">
-              <span>{c.db_name}</span>
-              <div className="flex gap-1">
-                <Button size="sm" variant="outline" onClick={() => handleToggleConn(c.id, c.enabled)}>
-                  {c.enabled ? 'Disable' : 'Enable'}
-                </Button>
-                <Button size="sm" variant="outline" onClick={() => openEditConn(c)}>
-                  <Pencil className="h-3 w-3" />
-                </Button>
-              </div>
-            </div>
+    <AppLayout sidebar={sidebar}>
+      <ScrollArea className="flex-1 px-4 py-4">
+        <div className="flex flex-col gap-3">
+          {messages.map((m) => (
+            <ChatBubble key={m.id} message={m} />
           ))}
-          <Separator className="my-2" />
-          <div className="space-y-1">
-            {convos.map((c) => (
-              <div
-                key={c.id}
-                className={cn('p-2 cursor-pointer', c.id === currentConvo && 'bg-accent')}
-                onClick={() => handleSelectConvo(c.id)}
-              >
-                {c.title || 'Untitled'}
-              </div>
-            ))}
-          </div>
+          <div ref={bottomRef} />
         </div>
-      </div>
-      <div className="flex flex-1 flex-col relative">
-        <Button
-          variant="outline"
-          size="sm"
-          className="absolute top-2 left-2 z-10 h-8 w-8 p-0"
-          onClick={() => setSidebarOpen((o) => !o)}
+      </ScrollArea>
+      {allError && <p className="px-4 text-sm text-red-500">{allError}</p>}
+      <Separator />
+      <div className="px-4 pb-4 pt-2 flex items-center gap-2">
+        <Select
+          value={selectedConn}
+          onValueChange={(v: string) => {
+            if (v === 'add') {
+              openAddConn()
+            } else {
+              setSelectedConn(v)
+            }
+          }}
         >
-          {sidebarOpen ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-        </Button>
-        <ScrollArea className="flex-1 px-4 py-4">
-          <div className="flex flex-col gap-3">
-            {messages.map((m) => (
-              <ChatBubble key={m.id} message={m} />
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="DB Connection" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="add">Add connection</SelectItem>
+            {dbConns.map((c) => (
+              <SelectItem key={c.id} value={c.id} disabled={!c.enabled}>
+                {c.db_name}
+              </SelectItem>
             ))}
-            <div ref={bottomRef} />
-          </div>
-        </ScrollArea>
-        {error && <p className="px-4 text-sm text-red-500">{error}</p>}
-        <Separator />
-        <div className="px-4 pb-4 pt-2 flex items-center gap-2">
-          <Select
-            value={selectedConn}
-            onValueChange={(v: string) => {
-              if (v === 'add') {
-                openAddConn()
-              } else {
-                setSelectedConn(v)
-              }
-            }}
-          >
-            <SelectTrigger className="w-[200px]">
-              <SelectValue placeholder="DB Connection" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="add">Add connection</SelectItem>
-              {dbConns.map((c) => (
-                <SelectItem key={c.id} value={c.id} disabled={!c.enabled}>
-                  {c.db_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
-            className="flex-1"
-            placeholder="Send a message..."
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                handleSend()
-              }
-            }}
-          />
-          <Button onClick={handleSend} disabled={sending}>
-            <Send className="h-4 w-4" />
-          </Button>
-        </div>
+          </SelectContent>
+        </Select>
+        <Input
+          className="flex-1"
+          placeholder="Send a message..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              handleSend()
+            }
+          }}
+        />
+        <Button onClick={handleSend} disabled={sending}>
+          <Send className="h-4 w-4" />
+        </Button>
       </div>
       <Dialog open={connOpen} onOpenChange={setConnOpen}>
         <DialogContent>
@@ -380,6 +267,6 @@ export default function Chat({ user }: Props) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </AppLayout>
   )
 }


### PR DESCRIPTION
## Summary
- extract reusable ChatBubble and AppLayout components
- centralize chat-related types and hooks for conversations and messages
- simplify Chat page using new hooks and layout

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae6062aa6c83239c6c34f639155bc2