### PR TITLE
refactor: validate message parts with schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ JWT cookie unless noted.
 - `POST /conversations` – create a conversation bound to a DB connection
 - `POST /conversations/{id}/query` – send a prompt and run the AI workflow. The
   response uses a standard envelope with `status`, `code`, and a `data.message`
-  array of parts. Each part is either `{ "type": "text" }` or `{ "type":
-  "data" }` for chart specifications. If the workflow needs more details,
-  follow-up questions are returned as text parts.
+  array of parts. Each part is validated using the `TextContent` or
+  `DataContent` schema to ensure consistent `{ "type": "text", "content": str }`
+  and `{ "type": "data", "content": ChartSpecification }` structures. If the
+  workflow needs more details, follow-up questions are returned as text parts.
 
 #### List conversations response
 

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -8,6 +8,9 @@ from ....schemas import (
     QueryResponse,
     ConversationDetail,
     ConversationListItem,
+    DataContent,
+    TextContent,
+    ChartSpecification,
 )
 from ....services import conversation_service
 from ....workflows import build_workflow
@@ -51,7 +54,7 @@ async def conversation_query(
     user_message_id = await conversation_service.add_message(
         conversation_id,
         "user",
-        [{"type": "text", "content": request.prompt}],
+        [TextContent(content=request.prompt).model_dump()],
         token_data["user_id"],
     )
 
@@ -79,9 +82,13 @@ async def conversation_query(
         questions = state.get("clarification_questions", [])
         response_text = "\n".join(questions)
 
-    assistant_contents = [{"type": "text", "content": response_text or ""}]
+    assistant_contents = [TextContent(content=response_text or "").model_dump()]
     if state.get("chart_spec"):
-        assistant_contents.append({"type": "data", "content": state.get("chart_spec")})
+        assistant_contents.append(
+            DataContent(
+                content=ChartSpecification(**state.get("chart_spec"))
+            ).model_dump()
+        )
 
     await conversation_service.add_message(
         conversation_id,

--- a/server/workflows/ai_workflow.py
+++ b/server/workflows/ai_workflow.py
@@ -25,6 +25,7 @@ from openai import OpenAI
 from ..config import settings
 # from ..services import conversation_service
 from ..services import step_log_service
+from ..schemas.conversation import DataContent, TextContent, ChartSpecification
 from sqlalchemy import MetaData, Table, create_engine, func, inspect, select
 
 
@@ -461,7 +462,9 @@ def data_retrieval(state: WorkflowState) -> WorkflowState:
         chart_spec = state.get("_chart_spec", {})
         if task is not None:
             task["sql"] = sql
-            task["result"] = {"type": "data", "content": chart_spec}
+            task["result"] = DataContent(
+                content=ChartSpecification(**chart_spec)
+            ).model_dump()
     except Exception as exc:
         logger.exception("Data retrieval failed: %s", exc)
         state["error"] = str(exc)
@@ -503,10 +506,9 @@ def text_generation(state: WorkflowState) -> WorkflowState:
     state["tokens_out"] = to
     task["token_in"] = ti
     task["token_out"] = to
-    task["result"] = {
-        "type": "text",
-        "content": resp.output[0].content[0].text.strip(),
-    }
+    task["result"] = TextContent(
+        content=resp.output[0].content[0].text.strip()
+    ).model_dump()
     state.setdefault("thought", []).append(
         {"step": "text_generation", "thought": "Generated text"}
     )


### PR DESCRIPTION
## Summary
- validate data and text message parts with `DataContent` and `TextContent` schemas
- route uses schema models for user and assistant message payloads
- document schema-backed message parts in API description

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff6ab9c648323a224f2979d7068d0