### PR TITLE
Load database URL from settings and log connection failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Environment variables:
 - `LLM_RESPONSE_MODEL` – LLM model used for final summaries
 - `CONVERSATION_MEMORY_K` – number of recent messages to keep verbatim in
   conversation memory
-- `DATABASE_URL` – connection string for the application's metadata DB
+- `DATABASE_URL` – connection string for the application's metadata DB. The server logs an error and exits if the database connection cannot be established.
 - `LOG_LEVEL` – logging level for the backend (default `INFO`)
 
 ## API overview

--- a/server/README.md
+++ b/server/README.md
@@ -11,7 +11,7 @@ Prerequisites
 Environment Variables
 - Location: place a `.env` file in `server/` (same folder as `main.py`). It is automatically loaded by `pydantic-settings`.
 - Required variables and where they are used:
-  - `DATABASE_URL`: Postgres connection string used by `db/database.py` (app runtime, migrations, and scripts).
+  - `DATABASE_URL`: Postgres connection string used by `db/database.py` (app runtime, migrations, and scripts). The server logs an error and exits if the pool cannot be created.
   - `LLM_API_KEY`: API key used by OpenAI clients in `workflows/steps/*` and `services/llm_service.py`.
   - `JWT_SECRET`: Cookie-signing secret used in `auth.py` for JWT creation/verification.
 - Optional variables:

--- a/server/config.py
+++ b/server/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     LLM_RESPONSE_MODEL: str = "gpt-4o-mini"
     LOG_LEVEL: str = "INFO"
     CONVERSATION_MEMORY_K: int = 5
+    DATABASE_URL: str
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -1,7 +1,12 @@
 from typing import Optional
 
-import os
 import asyncpg
+import logging
+
+from config import settings
+
+
+logger = logging.getLogger(__name__)
 
 _POOL: Optional[asyncpg.Pool] = None
 
@@ -98,8 +103,11 @@ async def get_pool() -> asyncpg.Pool:
     """Create (or reuse) a connection pool and ensure tables exist."""
     global _POOL
     if _POOL is None:
-        dsn = os.environ["DATABASE_URL"]
-        _POOL = await asyncpg.create_pool(dsn)
-        async with _POOL.acquire() as conn:
-            await conn.execute(CREATE_TABLES_SQL)
+        try:
+            _POOL = await asyncpg.create_pool(settings.DATABASE_URL)
+            async with _POOL.acquire() as conn:
+                await conn.execute(CREATE_TABLES_SQL)
+        except asyncpg.PostgresError:
+            logger.exception("Failed to connect to database")
+            raise SystemExit("Database connection failed")
     return _POOL


### PR DESCRIPTION
## Summary
- add `DATABASE_URL` to pydantic `Settings`
- use configured URL for asyncpg pool and exit with helpful log if connection fails
- document required `DATABASE_URL` and startup failure behavior

## Testing
- `python -m py_compile server/config.py server/db/database.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6497e70d08323a241c9fe6ad01784