### PR TITLE
feat: log agent runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ React + Vite front end and a FastAPI backend.
 - Each workflow step is logged with LLM thoughts, generated SQL, and token counts and can be inspected via `GET /api/v1/step-logs/{message_id}`
 - Workflow runs, individual steps, and agent executions are persisted in dedicated `workflow_run`, `workflow_step`, and `agent_run` tables for auditing with statuses (`running`, `succeeded`, `failed`, `cancelled`)
 - Detailed debug logs capture workflow step entry/exit and raw LLM responses; a helper wraps direct OpenAI calls to record raw output and automatically tags logs with the current workflow step
+- Each LLM invocation records its prompt, inputs, outputs, and token usage in the `agent_run` table for end-to-end traceability
 
 ## Structure
 

--- a/server/services/agent_run_service.py
+++ b/server/services/agent_run_service.py
@@ -1,0 +1,69 @@
+"""Service helpers for logging LLM agent executions."""
+import json
+import logging
+from typing import Any, Optional
+
+from db.database import get_pool
+
+logger = logging.getLogger(__name__)
+
+
+async def log_agent_run_start(
+    workflow_run_id: str,
+    prompt: str,
+    model_name: str,
+    workflow_step_id: Optional[str] = None,
+) -> str:
+    """Insert a new agent_run row and return its id."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO agent_run (workflow_run_id, workflow_step_id, model_name, prompt, status)
+            VALUES ($1, $2, $3, $4, 'running')
+            RETURNING id
+            """,
+            workflow_run_id,
+            workflow_step_id,
+            model_name,
+            prompt,
+        )
+        return str(row["id"])
+
+
+async def log_agent_run_end(
+    agent_run_id: str,
+    *,
+    input_json: Optional[Any] = None,
+    output_json: Optional[Any] = None,
+    thought: Optional[str] = None,
+    log: Optional[Any] = None,
+    token_usage: int = 0,
+    status: str = "succeeded",
+) -> None:
+    """Update an agent_run row with completion details."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE agent_run
+            SET input=$2,
+                output=$3,
+                thought=COALESCE($4, thought),
+                log=COALESCE($5, log),
+                token_usage=$6,
+                status=$7,
+                completed_at=now()
+            WHERE id=$1
+            """,
+            agent_run_id,
+            json.dumps(input_json) if input_json is not None else None,
+            json.dumps(output_json) if output_json is not None else None,
+            thought,
+            json.dumps(log) if log is not None else None,
+            token_usage,
+            status,
+        )
+
+
+__all__ = ["log_agent_run_start", "log_agent_run_end"]

--- a/server/services/logging_service.py
+++ b/server/services/logging_service.py
@@ -1,10 +1,13 @@
 """Logging helpers for workflow and LLM interactions."""
+import asyncio
 import json
 import logging
 from contextvars import ContextVar, Token
 from typing import Any, Tuple
 
 from openai import OpenAI
+
+from services import agent_run_service
 
 logger = logging.getLogger(__name__)
 
@@ -37,21 +40,110 @@ def log_llm_output(step: str, output: Any) -> None:
 
 
 def create_logged_response(
-    client: OpenAI, *, step: str | None = None, **kwargs: Any
+    client: OpenAI,
+    *,
+    step: str | None = None,
+    workflow_run_id: str | None = None,
+    workflow_step_id: str | None = None,
+    **kwargs: Any,
 ) -> Tuple[Any, str]:
     """Call ``client.responses.create`` and log the raw text output.
 
     If ``step`` is omitted, the current step name from ``@track_step`` is used
     when available. Returns the full response object along with the extracted
     text so callers can handle token accounting or parse the text as needed.
+    When ``workflow_run_id`` is provided, the call is recorded in ``agent_run``
+    for auditing.
     """
 
     step_name = step or get_current_step() or "unknown"
+    prompt = kwargs.get("input")
+    model_name = kwargs.get("model")
 
-    resp = client.responses.create(**kwargs)
+    agent_run_id: str | None = None
+    if workflow_run_id and prompt and model_name:
+        try:
+            agent_run_id = asyncio.run(
+                agent_run_service.log_agent_run_start(
+                    workflow_run_id,
+                    prompt,
+                    model_name,
+                    workflow_step_id,
+                )
+            )
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+            agent_run_id = loop.run_until_complete(
+                agent_run_service.log_agent_run_start(
+                    workflow_run_id,
+                    prompt,
+                    model_name,
+                    workflow_step_id,
+                )
+            )
+
+    try:
+        resp = client.responses.create(**kwargs)
+    except Exception as exc:
+        if agent_run_id:
+            try:
+                asyncio.run(
+                    agent_run_service.log_agent_run_end(
+                        agent_run_id,
+                        input_json=kwargs,
+                        output_json={"error": str(exc)},
+                        status="failed",
+                    )
+                )
+            except RuntimeError:
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(
+                    agent_run_service.log_agent_run_end(
+                        agent_run_id,
+                        input_json=kwargs,
+                        output_json={"error": str(exc)},
+                        status="failed",
+                    )
+                )
+        raise
+
     try:
         raw = resp.output[0].content[0].text
     except Exception:  # pragma: no cover - unexpected response shape
         raw = resp
+
     log_llm_output(step_name, raw)
+
+    if agent_run_id:
+        usage = getattr(resp, "usage", None)
+        token_usage = 0
+        if usage:
+            token_usage = (
+                getattr(usage, "total_tokens", 0)
+                or getattr(usage, "input_tokens", 0)
+                + getattr(usage, "output_tokens", 0)
+            )
+        output_json = resp.model_dump() if hasattr(resp, "model_dump") else raw
+        try:
+            asyncio.run(
+                agent_run_service.log_agent_run_end(
+                    agent_run_id,
+                    input_json=kwargs,
+                    output_json=output_json,
+                    log=raw,
+                    token_usage=token_usage,
+                )
+            )
+        except RuntimeError:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(
+                agent_run_service.log_agent_run_end(
+                    agent_run_id,
+                    input_json=kwargs,
+                    output_json=output_json,
+                    log=raw,
+                    token_usage=token_usage,
+                )
+            )
+
     return resp, raw


### PR DESCRIPTION
## Summary
- add `agent_run_service` to persist agent run start and completion details
- integrate service into LLM response helper so each call records prompt, I/O, and usage
- document agent run auditing in README

## Testing
- `cd server && uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba691f8f14832380d0f2ed3d65fb16