### PR TITLE
Add debug endpoints for workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Chart specifications returned in `data` parts follow this schema:
 
 Multiple chart types may be listed so the client can render the option it prefers.
 
+### Debug workflow steps
+- `POST /api/v1/debug/<step_name>` – run a single workflow step in isolation for
+  troubleshooting. The request body is treated as the workflow state and the
+  response is the step's output. Available steps include `prompt_intake`,
+  `intent_understanding`, `clarification`, `task_planning`, `task_execution`,
+  `text_generation`, `data_retrieval`, `visualization_spec`, `response_generation`,
+  `result_validation`, and `monitoring`.
+
 Clarifications are included as additional text parts. The API does not split
 prompts containing multiple questions, so the front end should either prompt the
 user for a single question or issue multiple calls.

--- a/server/api/v1/routes/__init__.py
+++ b/server/api/v1/routes/__init__.py
@@ -3,6 +3,7 @@ from api.v1.routes.db_connections import router as db_connections_router
 from api.v1.routes.conversations import router as conversations_router
 from api.v1.routes.step_logs import router as step_logs_router
 from api.v1.routes.mappings import router as mappings_router
+from api.v1.routes.debug import router as debug_router
 
 __all__ = [
     "users_router",
@@ -10,4 +11,5 @@ __all__ = [
     "conversations_router",
     "step_logs_router",
     "mappings_router",
+    "debug_router",
 ]

--- a/server/api/v1/routes/debug.py
+++ b/server/api/v1/routes/debug.py
@@ -1,0 +1,97 @@
+from fastapi import APIRouter, Depends
+
+from auth import verify_token
+from workflows.base import WorkflowState
+from workflows.steps.prompt_intake import prompt_intake
+from workflows.steps.intent_understanding import intent_understanding
+from workflows.steps.clarification import clarification
+from workflows.steps.task_planning import task_planning
+from workflows.steps.task_execution import task_execution
+from workflows.steps.text_generation import text_generation
+from workflows.steps.data_retrieval import data_retrieval
+from workflows.steps.visualization_spec import visualization_spec
+from workflows.steps.response_generation import response_generation
+from workflows.steps.result_validation import result_validation
+from workflows.steps.monitoring import monitoring
+
+router = APIRouter(prefix="/api/v1/debug")
+
+
+@router.post("/prompt_intake")
+async def debug_prompt_intake(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return prompt_intake(state)
+
+
+@router.post("/intent_understanding")
+async def debug_intent_understanding(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return intent_understanding(state)
+
+
+@router.post("/clarification")
+async def debug_clarification(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return clarification(state)
+
+
+@router.post("/task_planning")
+async def debug_task_planning(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return task_planning(state)
+
+
+@router.post("/task_execution")
+async def debug_task_execution(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return task_execution(state)
+
+
+@router.post("/text_generation")
+async def debug_text_generation(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return text_generation(state)
+
+
+@router.post("/data_retrieval")
+async def debug_data_retrieval(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return data_retrieval(state)
+
+
+@router.post("/visualization_spec")
+async def debug_visualization_spec(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return visualization_spec(state)
+
+
+@router.post("/response_generation")
+async def debug_response_generation(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return response_generation(state)
+
+
+@router.post("/result_validation")
+async def debug_result_validation(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return result_validation(state)
+
+
+@router.post("/monitoring")
+async def debug_monitoring(
+    state: WorkflowState, token_data: dict = Depends(verify_token)
+) -> WorkflowState:
+    return monitoring(state)
+
+
+__all__ = ["router"]

--- a/server/main.py
+++ b/server/main.py
@@ -12,6 +12,7 @@ from api.v1.routes import (
     conversations_router,
     step_logs_router,
     mappings_router,
+    debug_router,
 )
 from config import get_settings
 
@@ -66,3 +67,4 @@ app.include_router(db_connections_router)
 app.include_router(conversations_router)
 app.include_router(step_logs_router)
 app.include_router(mappings_router)
+app.include_router(debug_router)


### PR DESCRIPTION
## Summary
- expose POST `/api/v1/debug/<step_name>` routes for running workflow steps in isolation
- wire new debug router into FastAPI app
- document debug workflow endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba6cd5f09c83238fde7c0b7be44fdc