### PR TITLE
docs: update workflow state table

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ data types:
 | --- | --- | --- |
 | `conversation_id` | string | Current conversation identifier |
 | `message_id` | string | Message identifier for the current turn |
+| `workflow_run_id` | string | Workflow run identifier |
 | `user_id` | string | ID of the authenticated user |
 | `prompt` | string | Raw user input |
 | `history` | string | Concatenated summary and recent messages |
@@ -309,8 +310,8 @@ data types:
 | `clarification_limit` | integer | Maximum clarification attempts |
 | `clarification_escalated` | boolean | Whether the limit was exceeded |
 | `db_url` | string | Database connection string |
-| `error` | string | Error message if a step fails |
-| `response` | string | Final natural-language reply |
+| `error` | array<object> | Collected `{step, message}` errors |
+| `response` | object | Final response envelope (`QueryResponseData`) |
 | `summary` | string | Running conversation summary |
 | `messages` | array<object> | Recent conversation messages |
 | `timeframe` | string | Default or extracted timeframe |


### PR DESCRIPTION
## Summary
- document `workflow_run_id` and structured error/response fields in workflow state

## Testing
- `cd server && uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba6d75ad38832396133fd9308a8d94