### PR TITLE
Track checkpoints per workflow run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ React + Vite front end and a FastAPI backend.
   context within token limits, and each summary records its last refresh time -->
 - Chat UI built with reusable layout and custom hooks for conversations and messages
 - Conversation history is stored via a LangGraph checkpointer backed by
-  PostgreSQL, which keeps the latest K messages and summarizes older ones
+  PostgreSQL, which keeps the latest K messages and summarizes older ones.
+  Each workflow run records its own checkpoint row (indexed by conversation
+  ID and creation time) so memory can be restored from the most recent run.
 - Inline error messages with cleared loading indicators for failed API calls
 - Each workflow step captures foreseeable failures and appends them to
   `state["error"]` as `{step, message}` entries so the client receives
@@ -301,7 +303,9 @@ database and made available to downstream nodes via the workflow state. -->
 
 Conversation memory is maintained by a LangGraph checkpointer. It keeps the most
 recent **K** interactions verbatim and summarizes older messages, producing a
-compact history that is fed back into the workflow on subsequent turns.
+compact history that is fed back into the workflow on subsequent turns. A new
+checkpoint row is inserted for each workflow run via `create_checkpoint`, and the
+latest row is loaded when a conversation resumes.
 
 #### Workflow state
 

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -142,7 +142,7 @@ async def conversation_query(
     summary = state.get("summary", "")
     messages = state.get("messages", [])
     history_update = {"summary": summary, "messages": messages + new_messages}
-    checkpointer.save(conversation_id, history_update)
+    checkpointer.save(conversation_id, workflow_run_id, history_update)
 
     return result
 

--- a/server/db/database.py
+++ b/server/db/database.py
@@ -138,6 +138,8 @@ CREATE TABLE IF NOT EXISTS conversation_checkpoint (
   created_at TIMESTAMPTZ DEFAULT now(),
   updated_at TIMESTAMPTZ DEFAULT now()
 );
+CREATE INDEX IF NOT EXISTS idx_conv_checkpoint_convo_created
+  ON conversation_checkpoint (conversation_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS workflow_step_log (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/services/checkpoint_service.py
+++ b/server/services/checkpoint_service.py
@@ -4,12 +4,18 @@ from typing import Any, Dict, Optional
 from db.database import get_pool
 
 
-async def get_checkpoint(conversation_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch checkpoint data for a conversation."""
+async def get_latest_checkpoint(conversation_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch the most recent checkpoint for a conversation."""
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT checkpoint FROM conversation_checkpoint WHERE conversation_id=$1",
+            """
+            SELECT checkpoint
+            FROM conversation_checkpoint
+            WHERE conversation_id=$1
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
             conversation_id,
         )
         if row:
@@ -17,17 +23,20 @@ async def get_checkpoint(conversation_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-async def upsert_checkpoint(conversation_id: str, checkpoint: Dict[str, Any]) -> None:
-    """Insert or update checkpoint data for a conversation."""
+async def create_checkpoint(
+    conversation_id: str, workflow_run_id: str, checkpoint: Dict[str, Any]
+) -> None:
+    """Insert checkpoint data for a conversation and workflow run."""
     pool = await get_pool()
     async with pool.acquire() as conn:
         await conn.execute(
             """
-            INSERT INTO conversation_checkpoint (conversation_id, checkpoint, updated_at)
-            VALUES ($1, $2, now())
-            ON CONFLICT (conversation_id)
-            DO UPDATE SET checkpoint=$2, updated_at=now()
+            INSERT INTO conversation_checkpoint (
+                conversation_id, workflow_run_id, checkpoint
+            )
+            VALUES ($1, $2, $3)
             """,
             conversation_id,
+            workflow_run_id,
             json.dumps(checkpoint),
         )

--- a/server/workflows/checkpointer.py
+++ b/server/workflows/checkpointer.py
@@ -57,23 +57,35 @@ class ConversationCheckpointer(InMemorySaver):
 
     def _load_from_db(self, conversation_id: str) -> Dict[str, Any] | None:
         try:
-            return asyncio.run(checkpoint_service.get_checkpoint(conversation_id))
+            return asyncio.run(
+                checkpoint_service.get_latest_checkpoint(conversation_id)
+            )
         except RuntimeError:
             loop = asyncio.get_event_loop()
             return loop.run_until_complete(
-                checkpoint_service.get_checkpoint(conversation_id)
+                checkpoint_service.get_latest_checkpoint(conversation_id)
             )
 
-    def _save_to_db(self, conversation_id: str, data: Dict[str, Any]) -> None:
+    def _save_to_db(
+        self, conversation_id: str, workflow_run_id: str, data: Dict[str, Any]
+    ) -> None:
         try:
-            asyncio.run(checkpoint_service.upsert_checkpoint(conversation_id, data))
+            asyncio.run(
+                checkpoint_service.create_checkpoint(
+                    conversation_id, workflow_run_id, data
+                )
+            )
         except RuntimeError:
             loop = asyncio.get_event_loop()
             loop.run_until_complete(
-                checkpoint_service.upsert_checkpoint(conversation_id, data)
+                checkpoint_service.create_checkpoint(
+                    conversation_id, workflow_run_id, data
+                )
             )
 
-    def load(self, conversation_id: str) -> Dict[str, Any]:
+    def load(
+        self, conversation_id: str, workflow_run_id: str | None = None
+    ) -> Dict[str, Any]:
         """Load memory for a conversation."""
         config = {
             "configurable": {"thread_id": conversation_id, "checkpoint_ns": "memory"}
@@ -95,7 +107,9 @@ class ConversationCheckpointer(InMemorySaver):
             return history
         return checkpoint.get("history", {"summary": "", "messages": []})
 
-    def save(self, conversation_id: str, history: Dict[str, Any]) -> None:
+    def save(
+        self, conversation_id: str, workflow_run_id: str, history: Dict[str, Any]
+    ) -> None:
         messages = history.get("messages", [])
         summary = history.get("summary", "")
         if len(messages) > self.k:
@@ -113,4 +127,4 @@ class ConversationCheckpointer(InMemorySaver):
             {},
             {"history": self.get_next_version(None, None)},
         )
-        self._save_to_db(conversation_id, {"history": new_history})
+        self._save_to_db(conversation_id, workflow_run_id, {"history": new_history})

--- a/server/workflows/steps/prompt_intake.py
+++ b/server/workflows/steps/prompt_intake.py
@@ -12,7 +12,7 @@ def prompt_intake(state: WorkflowState, checkpointer=None) -> WorkflowState:
     conv_id = state.get("conversation_id")
     if conv_id and checkpointer:
         try:
-            history = checkpointer.load(conv_id)
+            history = checkpointer.load(conv_id, state.get("workflow_run_id"))
         except Exception as exc:
             logger.exception(
                 "Failed to load conversation %s: %s", conv_id, exc


### PR DESCRIPTION
## Summary
- store each conversation checkpoint per workflow run and fetch the latest row
- pass `workflow_run_id` through checkpointer load/save
- index conversation checkpoints by conversation and creation time
- rename checkpoint writer to `create_checkpoint` for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba90b4e41c8323bdcdbbb548b21751