### PR TITLE
feat: centralize LLM response schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ React + Vite front end and a FastAPI backend.
 - Workflow runs, individual steps, and agent executions are persisted in dedicated `workflow_run`, `workflow_step`, and `agent_run` tables. Each step record captures the step name, status, and input/output workflow state for auditing
 - Each conversation query automatically records a `workflow_run` row when it starts and marks it `completed` on success or `failed` if the workflow errors
 - Detailed debug logs capture workflow step entry/exit and raw LLM responses; a helper wraps direct OpenAI calls to record raw output and automatically tags logs with the current workflow step
+- Prompts sent to LLMs are wrapped with strict prefix and suffix instructions (see `server/services/prompt_wrapper.py`) derived from the `LLMResponse` model. Every reply must be a JSON object with a single `response` field holding the final answer, and if the prompt asks for a specific JSON structure it is nested inside `response`. Changing `LLMResponse` updates both the wrapper and response parsing.
 - Each LLM invocation records its prompt, inputs, outputs, and token usage in the `agent_run` table for end-to-end traceability
 
 ## Structure

--- a/server/README.md
+++ b/server/README.md
@@ -4,6 +4,7 @@ Overview
 - FastAPI backend for the LLM Data Analyst app.
 - Serves REST endpoints for users, DB connections, conversations, step logs, and semantic mappings under `/users`, `/db-connections`, `/conversations`, `/step-logs`, and `/mappings`.
 - Debug logs mark entry and exit of each workflow step and capture raw LLM output; OpenAI calls made through a helper automatically include the current step name.
+- Prompts are automatically wrapped with strict prefix and suffix instructions derived from the `LLMResponse` model (`schemas/llm.py`). Responses must be JSON objects with a single `response` field containing the final answer, and any JSON structure requested by the prompt is nested inside `response`. Adjusting this model updates both the prompt wrapper and response parsing.
 - Workflow runs, steps, and agent invocations are stored in Postgres tables for auditing and debugging. Status fields use a shared `run_status` enum (`running`, `succeeded`, `failed`, `cancelled`).
 
 Prerequisites

--- a/server/schemas/__init__.py
+++ b/server/schemas/__init__.py
@@ -3,3 +3,4 @@ from .db_connection import *  # noqa: F401,F403
 from .conversation import *  # noqa: F401,F403
 from .common import *  # noqa: F401,F403
 from .workflow_step_log import *  # noqa: F401,F403
+from .llm import *  # noqa: F401,F403

--- a/server/schemas/llm.py
+++ b/server/schemas/llm.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class LLMResponse(BaseModel):
+    """Standard response wrapper for LLM outputs."""
+
+    response: Any

--- a/server/services/llm_service.py
+++ b/server/services/llm_service.py
@@ -9,7 +9,7 @@ from langchain.agents.agent_toolkits import create_sql_agent
 from langchain_community.utilities import SQLDatabase
 from langchain_openai import ChatOpenAI
 
-from schemas import DBConnection
+from schemas import DBConnection, LLMResponse
 from config import get_settings
 from services.logging_service import log_llm_output, create_logged_response
 
@@ -41,7 +41,7 @@ async def extract_data(
             llm, db, agent_type=AgentType.OPENAI_FUNCTIONS, verbose=False
         )
 
-        query = (f"{prompt}\n" "Return the results as a JSON array of objects.")
+        query = f"{prompt}\nReturn the results as a JSON array of objects."
         result = agent.invoke({"input": query})
         log_llm_output("extract_data", result)
         data_text = result["output"] if isinstance(result, dict) else result
@@ -70,11 +70,17 @@ async def choose_charts(
             "json_schema": {
                 "name": "chart_recommendations",
                 "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": available_charts,
+                    "type": "object",
+                    "properties": {
+                        "response": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": available_charts,
+                            },
+                        }
                     },
+                    "required": ["response"],
                 },
             },
         }
@@ -93,7 +99,7 @@ async def choose_charts(
             input=message,
             response_format=response_format,
         )
-        selections = json.loads(raw)
+        selections = LLMResponse.model_validate_json(raw).response
         return list(selections)
 
     return await asyncio.to_thread(_run)

--- a/server/services/logging_service.py
+++ b/server/services/logging_service.py
@@ -8,6 +8,7 @@ from typing import Any, Tuple
 from openai import OpenAI
 
 from services import agent_run_service
+from services.prompt_wrapper import wrap_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +54,15 @@ def create_logged_response(
     when available. Returns the full response object along with the extracted
     text so callers can handle token accounting or parse the text as needed.
     When ``workflow_run_id`` is provided, the call is recorded in ``agent_run``
-    for auditing.
+    for auditing. Prompts are automatically wrapped with
+    :func:`services.prompt_wrapper.wrap_prompt` so all responses conform to
+    :class:`schemas.LLMResponse`.
     """
 
     step_name = step or get_current_step() or "unknown"
     prompt = kwargs.get("input")
+    if isinstance(prompt, str):
+        kwargs["input"] = wrap_prompt(prompt)
     model_name = kwargs.get("model")
 
     agent_run_id: str | None = None

--- a/server/services/prompt_wrapper.py
+++ b/server/services/prompt_wrapper.py
@@ -1,0 +1,33 @@
+"""Utilities for wrapping LLM prompts with standard instructions."""
+from __future__ import annotations
+
+import json
+
+from schemas import LLMResponse
+
+
+def _build_prefix() -> str:
+    schema = json.dumps(LLMResponse.model_json_schema(), separators=(",", ":"))
+    return (
+        "You must respond with a JSON object that matches this schema:\n"
+        f"{schema}\n"
+        "This is a 100% requirement. Do not include any text outside the JSON object. "
+        "If the user's prompt requests its own JSON structure, place that JSON inside the `response` field. "
+        "The `response` field must contain the final user-facing answer."
+    )
+
+
+PROMPT_PREFIX = _build_prefix()
+
+
+def _build_suffix() -> str:
+    return "Return only the JSON object described above and nothing else."
+
+
+PROMPT_SUFFIX = _build_suffix()
+
+
+def wrap_prompt(prompt: str) -> str:
+    """Wrap ``prompt`` with :data:`PROMPT_PREFIX` and :data:`PROMPT_SUFFIX`."""
+
+    return f"{PROMPT_PREFIX.strip()}\n{prompt}\n{PROMPT_SUFFIX.strip()}"

--- a/server/tests/test_prompt_wrapper.py
+++ b/server/tests/test_prompt_wrapper.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+import types
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+schemas_stub = types.ModuleType("schemas")
+
+
+class _StubLLMResponse:
+    @classmethod
+    def model_json_schema(cls):
+        return {"title": "LLMResponse", "type": "object", "properties": {"response": {}}}
+
+
+schemas_stub.LLMResponse = _StubLLMResponse
+sys.modules.setdefault("schemas", schemas_stub)
+
+import services.prompt_wrapper as pw
+
+
+def test_wrap_prompt_adds_prefix_and_suffix():
+    prompt = "Hello"
+    wrapped = pw.wrap_prompt(prompt)
+    expected = f"{pw.PROMPT_PREFIX.strip()}\n{prompt}\n{pw.PROMPT_SUFFIX.strip()}"
+    assert wrapped == expected
+
+
+def test_prompt_prefix_mentions_json_requirements():
+    assert "100% requirement" in pw.PROMPT_PREFIX
+    assert "response" in pw.PROMPT_PREFIX
+    assert "place that JSON inside the `response` field" in pw.PROMPT_PREFIX
+
+
+def test_prompt_suffix_requires_only_json():
+    assert "nothing else" in pw.PROMPT_SUFFIX

--- a/server/workflows/checkpointer.py
+++ b/server/workflows/checkpointer.py
@@ -6,9 +6,11 @@ from openai import OpenAI
 
 from config import get_settings
 
-settings = get_settings()
+from schemas import LLMResponse
 from services import checkpoint_service
 from services.logging_service import create_logged_response
+
+settings = get_settings()
 
 
 class ConversationCheckpointer(InMemorySaver):
@@ -42,7 +44,7 @@ class ConversationCheckpointer(InMemorySaver):
         parts.append("New messages:\n" + "\n".join(formatted))
         prompt = "\n\n".join(parts)
         try:
-            resp, text = create_logged_response(
+            resp, raw = create_logged_response(
                 self.client,
                 step="conversation_summary",
                 model=settings.LLM_RESPONSE_MODEL,
@@ -51,7 +53,7 @@ class ConversationCheckpointer(InMemorySaver):
                     + prompt
                 ),
             )
-            return text.strip()
+            return LLMResponse.model_validate_json(raw).response.strip()
         except Exception:
             return summary
 

--- a/server/workflows/steps/intent_understanding.py
+++ b/server/workflows/steps/intent_understanding.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, List
 
 from openai import OpenAI
 
 from config import get_settings
 from semantic.mapper import resolve_term
+
+from schemas import LLMResponse
 
 settings = get_settings()
 from workflows.base import WorkflowState, logger, track_step, append_error
@@ -28,27 +29,33 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
             "schema": {
                 "type": "object",
                 "properties": {
-                    "intent": {"type": "string"},
-                    "entities": {
+                    "response": {
                         "type": "object",
                         "properties": {
-                            "metrics": {
+                            "intent": {"type": "string"},
+                            "entities": {
+                                "type": "object",
+                                "properties": {
+                                    "metrics": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                    "dimensions": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                    "timeframe": {"type": "string"},
+                                },
+                            },
+                            "clarification_questions": {
                                 "type": "array",
                                 "items": {"type": "string"},
                             },
-                            "dimensions": {
-                                "type": "array",
-                                "items": {"type": "string"},
-                            },
-                            "timeframe": {"type": "string"},
                         },
-                    },
-                    "clarification_questions": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                    },
+                        "required": ["intent", "entities", "clarification_questions"],
+                    }
                 },
-                "required": ["intent", "entities", "clarification_questions"],
+                "required": ["response"],
             },
         },
     }
@@ -70,7 +77,7 @@ def intent_understanding(state: WorkflowState) -> WorkflowState:
         if getattr(resp, "usage", None):
             state["tokens_in"] = getattr(resp.usage, "input_tokens", 0)
             state["tokens_out"] = getattr(resp.usage, "output_tokens", 0)
-        parsed = json.loads(raw_text)
+        parsed = LLMResponse.model_validate_json(raw_text).response
     except Exception as exc:  # pragma: no cover - LLM failure fallback
         logger.exception("Failed to parse intent response: %s", exc)
         append_error(state, "intent_understanding", str(exc))

--- a/server/workflows/steps/task_planning.py
+++ b/server/workflows/steps/task_planning.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import json
 from typing import Any, Dict, List
 
 from openai import OpenAI
 
 from config import get_settings
+
+from schemas import LLMResponse
 
 settings = get_settings()
 from workflows.base import WorkflowState, logger, track_step, append_error
@@ -26,19 +27,25 @@ def task_planning(state: WorkflowState) -> WorkflowState:
             "schema": {
                 "type": "object",
                 "properties": {
-                    "tasks": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "description": {"type": "string"},
-                                "requires_data": {"type": "boolean"},
-                            },
-                            "required": ["description", "requires_data"],
+                    "response": {
+                        "type": "object",
+                        "properties": {
+                            "tasks": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "description": {"type": "string"},
+                                        "requires_data": {"type": "boolean"},
+                                    },
+                                    "required": ["description", "requires_data"],
+                                },
+                            }
                         },
+                        "required": ["tasks"],
                     }
                 },
-                "required": ["tasks"],
+                "required": ["response"],
             },
         },
     }
@@ -57,7 +64,7 @@ def task_planning(state: WorkflowState) -> WorkflowState:
         if getattr(resp, "usage", None):
             state["tokens_in"] = getattr(resp.usage, "input_tokens", 0)
             state["tokens_out"] = getattr(resp.usage, "output_tokens", 0)
-        data = json.loads(raw)
+        data = LLMResponse.model_validate_json(raw).response
         planned = data.get("tasks", [])
     except Exception as exc:
         logger.exception("Task planning failed: %s", exc)

--- a/server/workflows/steps/text_generation.py
+++ b/server/workflows/steps/text_generation.py
@@ -4,10 +4,12 @@ from openai import OpenAI
 
 from config import get_settings
 
-settings = get_settings()
+from schemas import LLMResponse
 from schemas.conversation import TextContent
 from workflows.base import WorkflowState, logger, track_step, append_error
 from services.logging_service import create_logged_response
+
+settings = get_settings()
 
 
 @track_step("text_generation")
@@ -37,7 +39,8 @@ def text_generation(state: WorkflowState) -> WorkflowState:
         state["tokens_out"] = to
         task["token_in"] = ti
         task["token_out"] = to
-        task["result"] = TextContent(content=raw.strip()).model_dump()
+        answer = LLMResponse.model_validate_json(raw).response
+        task["result"] = TextContent(content=answer).model_dump()
     except Exception as exc:  # pragma: no cover - LLM failure fallback
         logger.exception("Text generation failed: %s", exc)
         msg = str(exc)


### PR DESCRIPTION
## Summary
- derive prompt wrapper from reusable `LLMResponse` schema and append both prefix and suffix instructions to every LLM call
- document the prefix/suffix behavior in top-level and server READMEs
- add unit tests covering the prompt wrapper

## Testing
- `cd server && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be45021a888323bd93528ff7ed6e36