### PR TITLE
feat: allow database URL in connection form

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ React + Vite front end and a FastAPI backend.
 - User registration and login with JWT stored in HTTP‑only cookies; no credentials are kept in
   `localStorage`
 - Manage and enable/disable database connections
+- Connection form allows toggling between a full database URL or separate host credentials, disabling unused credential inputs while keeping the database name editable
 - Create conversations and retrieve full message history
 - Toggleable sidebar for switching conversations and configuring connections, fetching conversations on mount
 - Optional mock user, conversation, and message data for frontend development
@@ -487,4 +488,8 @@ connection for creating, updating, enabling, and disabling connections on the
 client.
 
 On first launch, register an account on the login page. After logging in, create a
-database connection from the dropdown to start a conversation and run queries.
+database connection from the dropdown to start a conversation and run queries. The
+connection dialog now lists the Database Name field first, followed by a separator and a
+checkbox to switch between a full connection URL and separate host credentials. Host
+credential fields are disabled when using a URL, while the URL field is disabled when
+supplying individual credentials. The Database Name field remains editable in both modes.

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   DBConnection,
   MessageContent,
   QueryResponse,
@@ -84,14 +84,26 @@ export async function listDbConnections() {
 export async function createDbConnection(body: DBConnection & { user_id: string }) {
   if (USE_MOCK_DB_CONNECTIONS) {
     const id = crypto.randomUUID()
-    mockDbConnections.push({
-      id,
-      db_name: body.db_name,
-      host: body.host ?? 'localhost',
-      port: body.port,
-      user: body.user,
-      enabled: true,
-    })
+    if (body.url) {
+      const parsed = new URL(body.url)
+      mockDbConnections.push({
+        id,
+        db_name: body.db_name ?? '',
+        host: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : 5432,
+        user: parsed.username,
+        enabled: true,
+      })
+    } else {
+      mockDbConnections.push({
+        id,
+        db_name: body.db_name ?? '',
+        host: body.host ?? 'localhost',
+        port: body.port ?? 5432,
+        user: body.user ?? '',
+        enabled: true,
+      })
+    }
     return { db_connection_id: id }
   }
   return fetchJson<{ db_connection_id: string }>(`${API_BASE}/db-connections`, {
@@ -106,10 +118,18 @@ export async function updateDbConnection(id: string, body: DBConnection & { user
   if (USE_MOCK_DB_CONNECTIONS) {
     const conn = mockDbConnections.find((c) => c.id === id)
     if (conn) {
-      conn.db_name = body.db_name
-      conn.host = body.host ?? 'localhost'
-      conn.port = body.port
-      conn.user = body.user
+      if (body.url) {
+        const parsed = new URL(body.url)
+        conn.db_name = body.db_name ?? conn.db_name
+        conn.host = parsed.hostname
+        conn.port = parsed.port ? Number(parsed.port) : 5432
+        conn.user = parsed.username
+      } else {
+        conn.db_name = body.db_name ?? conn.db_name
+        conn.host = body.host ?? conn.host
+        conn.port = body.port ?? conn.port
+        conn.user = body.user ?? conn.user
+      }
     }
     return { status: 'ok' }
   }

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -4,11 +4,12 @@ export type User = {
 }
 
 export type DBConnection = {
-  db_name: string
-  user: string
-  password: string
+  db_name?: string
+  user?: string
+  password?: string
   host?: string
-  port: number
+  port?: number
+  url?: string
 }
 
 export type DBConnItem = {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
-import type { MessageContent } from "./api"
+import type { MessageContent } from "./types"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -40,7 +40,15 @@ export default function Chat({ user }: Props) {
   const [selectedConn, setSelectedConn] = useState<string | undefined>()
   const [connOpen, setConnOpen] = useState(false)
   const [editingConn, setEditingConn] = useState<string | null>(null)
-  const [connForm, setConnForm] = useState({ db_name: '', host: '', port: 5432, user: '', password: '' })
+  const [useUrl, setUseUrl] = useState(false)
+  const [connForm, setConnForm] = useState({
+    db_name: '',
+    host: '',
+    port: 5432,
+    user: '',
+    password: '',
+    url: '',
+  })
   const [connLoading, setConnLoading] = useState(false)
 
   const {
@@ -97,8 +105,16 @@ export default function Chat({ user }: Props) {
     setError(null)
     setMsgError(null)
     setConnLoading(true)
-    const body = { ...connForm, user_id: user.user_id }
+    let body
     try {
+      if (useUrl) {
+        body = { db_name: connForm.db_name, url: connForm.url, user_id: user.user_id }
+      } else {
+        const { url, ...rest } = connForm
+        void url
+        body = { ...rest, user_id: user.user_id }
+      }
+
       if (editingConn) {
         await updateDbConnection(editingConn, body)
       } else {
@@ -126,13 +142,22 @@ export default function Chat({ user }: Props) {
 
   const openAddConn = () => {
     setEditingConn(null)
-    setConnForm({ db_name: '', host: '', port: 5432, user: '', password: '' })
+    setUseUrl(false)
+    setConnForm({ db_name: '', host: '', port: 5432, user: '', password: '', url: '' })
     setConnOpen(true)
   }
 
   const openEditConn = (c: DBConnItem) => {
     setEditingConn(c.id)
-    setConnForm({ db_name: c.db_name, host: c.host, port: c.port, user: c.user, password: '' })
+    setUseUrl(false)
+    setConnForm({
+      db_name: c.db_name,
+      host: c.host,
+      port: c.port,
+      user: c.user,
+      password: '',
+      url: '',
+    })
     setConnOpen(true)
   }
 
@@ -232,29 +257,54 @@ export default function Chat({ user }: Props) {
             <Input
               placeholder="Database Name"
               value={connForm.db_name}
-              onChange={(e) => setConnForm({ ...connForm, db_name: e.target.value })}
+              onChange={(e) =>
+                setConnForm({ ...connForm, db_name: e.target.value })
+              }
+            />
+            <Separator />
+            <label className="flex items-center space-x-2 text-sm">
+              <input
+                type="checkbox"
+                checked={useUrl}
+                onChange={(e) => setUseUrl(e.target.checked)}
+              />
+              <span>Use database URL</span>
+            </label>
+            <Input
+              placeholder="Database URL"
+              value={connForm.url}
+              onChange={(e) => setConnForm({ ...connForm, url: e.target.value })}
+              disabled={!useUrl}
             />
             <Input
               placeholder="Host"
               value={connForm.host}
               onChange={(e) => setConnForm({ ...connForm, host: e.target.value })}
-            />
-            <Input
-              placeholder="Port"
-              type="number"
-              value={connForm.port}
-              onChange={(e) => setConnForm({ ...connForm, port: Number(e.target.value) })}
+              disabled={useUrl}
             />
             <Input
               placeholder="Username"
               value={connForm.user}
               onChange={(e) => setConnForm({ ...connForm, user: e.target.value })}
+              disabled={useUrl}
             />
             <Input
               placeholder="Password"
               type="password"
               value={connForm.password}
-              onChange={(e) => setConnForm({ ...connForm, password: e.target.value })}
+              onChange={(e) =>
+                setConnForm({ ...connForm, password: e.target.value })
+              }
+              disabled={useUrl}
+            />
+            <Input
+              placeholder="Port"
+              type="number"
+              value={connForm.port}
+              onChange={(e) =>
+                setConnForm({ ...connForm, port: Number(e.target.value) })
+              }
+              disabled={useUrl}
             />
           </div>
           <DialogFooter>


### PR DESCRIPTION
## Summary
- keep Database Name input active when using a connection URL
- always send `db_name` with the URL and use it in mock API handlers
- document that unused fields are disabled when toggling between URL and host credentials
- list Database Name first in the connection dialog, followed by a separator and the URL toggle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfc3b3ee1c8323aa760742593e1423