### PR TITLE
docs: clarify shadcn ui rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 # Agent Guidelines
 
 - If you modify any source code (e.g. files in `client/` or `server/`), update `README.md` to reflect the changes.
-
+- Components in `client/src/components/ui` are shadcn components and must not be modified; they may only be read.


### PR DESCRIPTION
## Summary
- document that `client/src/components/ui` contains read-only shadcn components

## Testing
- `pytest` (fails: assert '100% requirement' in PROMPT_PREFIX, assert 'nothing else' in PROMPT_SUFFIX)


------
https://chatgpt.com/codex/tasks/task_e_68c0d22bd914832380d1ca1a5fa3558f