### PR TITLE
Use shadcn sidebar component in AppLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ React + Vite front end and a FastAPI backend.
 - Manage and enable/disable database connections
 - Connection form allows toggling between a full database URL or separate host credentials, disabling unused credential inputs while keeping the database name editable
 - Create conversations and retrieve full message history
-- Toggleable sidebar for switching conversations and configuring connections, fetching conversations on mount
+- Toggleable sidebar built with a shadcn UI component for switching conversations and configuring connections, fetching conversations on mount
 - Optional mock user, conversation, and message data for frontend development
 - <!-- Conversations are summarized after each assistant reply using an LLM to keep
   context within token limits, and each summary records its last refresh time -->

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { Button } from '@/components/ui/button'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/components/ui/sidebar'
 
 type Props = {
   sidebar: ReactNode
@@ -10,23 +13,17 @@ type Props = {
 }
 
 export function AppLayout({ sidebar, children }: Props) {
-  const [open, setOpen] = useState(true)
   return (
-    <div className="flex h-dvh w-full">
-      <div className={cn('border-r overflow-y-auto transition-all', open ? 'w-64' : 'w-0')}>
-        <div className={cn('p-2', open ? 'block' : 'hidden')}>{sidebar}</div>
+    <SidebarProvider>
+      <div className="flex h-dvh w-full">
+        <Sidebar>
+          <SidebarContent>{sidebar}</SidebarContent>
+        </Sidebar>
+        <SidebarInset>
+          <SidebarTrigger className="absolute top-2 left-2 z-10 size-8" />
+          {children}
+        </SidebarInset>
       </div>
-      <div className="flex flex-1 flex-col relative">
-        <Button
-          variant="outline"
-          size="sm"
-          className="absolute top-2 left-2 z-10 h-8 w-8 p-0"
-          onClick={() => setOpen((o) => !o)}
-        >
-          {open ? <ChevronLeft className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-        </Button>
-        {children}
-      </div>
-    </div>
+    </SidebarProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Replace custom sidebar in AppLayout with shadcn Sidebar components
- Note use of shadcn sidebar in README feature list

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d4b247048323848cfb9d3cad1127