### PR TITLE
feat: popover for db connection selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ React + Vite front end and a FastAPI backend.
 - User registration and login with JWT stored in HTTP‑only cookies; no credentials are kept in
   `localStorage`
 - Manage and enable/disable database connections
+- Select database connections for new conversations via a popover
 - Connection form allows toggling between a full database URL or separate host credentials, disabling unused credential inputs while keeping the database name editable
 - Create conversations and retrieve full message history
 - Toggleable sidebar for switching conversations and configuring connections, fetching conversations on mount
@@ -487,8 +488,8 @@ schema and reuse the mock user's ID for foreign keys. Set
 connection for creating, updating, enabling, and disabling connections on the
 client.
 
-On first launch, register an account on the login page. After logging in, create a
-database connection from the dropdown to start a conversation and run queries. The
+On first launch, register an account on the login page. After logging in, select a
+database connection from the popover to start a conversation and run queries. The
 connection dialog now lists the Database Name field first, followed by a separator and a
 checkbox to switch between a full connection URL and separate host credentials. Host
 credential fields are disabled when using a URL, while the URL field is disabled when

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -3,12 +3,10 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from '@/components/ui/select'
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover'
 import {
   Dialog,
   DialogContent,
@@ -38,6 +36,7 @@ type Props = { user: User }
 export default function Chat({ user }: Props) {
   const [dbConns, setDbConns] = useState<DBConnItem[]>([])
   const [selectedConn, setSelectedConn] = useState<string | undefined>()
+  const [connSelectOpen, setConnSelectOpen] = useState(false)
   const [connOpen, setConnOpen] = useState(false)
   const [editingConn, setEditingConn] = useState<string | null>(null)
   const [useUrl, setUseUrl] = useState(false)
@@ -210,28 +209,43 @@ export default function Chat({ user }: Props) {
       {allError && <p className="px-4 text-sm text-red-500">{allError}</p>}
       <Separator />
       <div className="px-4 pb-4 pt-2 flex items-center gap-2">
-        <Select
-          value={selectedConn}
-          onValueChange={(v: string) => {
-            if (v === 'add') {
-              openAddConn()
-            } else {
-              setSelectedConn(v)
-            }
-          }}
-        >
-          <SelectTrigger className="w-[200px]">
-            <SelectValue placeholder="DB Connection" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="add">Add connection</SelectItem>
-            {dbConns.map((c) => (
-              <SelectItem key={c.id} value={c.id} disabled={!c.enabled}>
-                {c.db_name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Popover open={connSelectOpen} onOpenChange={setConnSelectOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="w-[200px] justify-start">
+              {selectedConn
+                ? dbConns.find((c) => c.id === selectedConn)?.db_name
+                : 'DB Connection'}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="p-0 w-[200px]">
+            <div className="flex flex-col">
+              <Button
+                variant="ghost"
+                className="justify-start"
+                onClick={() => {
+                  openAddConn()
+                  setConnSelectOpen(false)
+                }}
+              >
+                Add connection
+              </Button>
+              {dbConns.map((c) => (
+                <Button
+                  key={c.id}
+                  variant="ghost"
+                  className="justify-start"
+                  disabled={!c.enabled}
+                  onClick={() => {
+                    setSelectedConn(c.id)
+                    setConnSelectOpen(false)
+                  }}
+                >
+                  {c.db_name}
+                </Button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
         <Input
           className="flex-1"
           placeholder="Send a message..."


### PR DESCRIPTION
## Summary
- use ShadCN popover to choose database connections when starting new conversations
- document popover-based connection selection in README

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: react-refresh/only-export-components in shadcn components)
- `npx eslint src/pages/Chat.tsx`
- `npm run build` (fails: TS1484 in sidebar.tsx)
- `npx tsc src/pages/Chat.tsx --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c0d50c7a18832398e7c8e7acd7c754