### PR TITLE
Show streamed tokens in chat bubble

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ React + Vite front end and a FastAPI backend.
 - Chat responses stream token-by-token through a Fly.io worker using Redis
   Streams and Server-Sent Events, allowing the UI to render assistant output in
   real time
+- Chat bubbles display streamed tokens as they arrive, showing partial
+  assistant responses even while messages are pending
 - Guardrail checks validate generated SQL and responses, detecting PII or
   profanity and halting the workflow on violations
 - Intent classification and entity extraction are handled by an LLM instead of keyword heuristics

--- a/client/src/components/ChatBubble.tsx
+++ b/client/src/components/ChatBubble.tsx
@@ -19,14 +19,15 @@ export function ChatBubble({ message }: { message: Message }) {
             : 'bg-secondary text-secondary-foreground rounded-bl-sm'
         )}
       >
-        {message.pending ? (
+        <pre className="whitespace-pre-wrap break-words font-sans">
+          {message.content}
+        </pre>
+        {message.pending && (
           <span className="inline-flex items-center gap-1 opacity-70">
             <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.2s]"></span>
             <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.1s]"></span>
             <span className="inline-block h-1.5 w-1.5 animate-bounce rounded-full bg-current"></span>
           </span>
-        ) : (
-          <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
         )}
       </div>
       {isUser && (


### PR DESCRIPTION
## Summary
- display partial assistant messages even while they are still pending
- document that chat bubbles reveal streamed tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in shadcn UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68c39114b58483239e3e5f3291189705