### PR TITLE
feat: generate conversation titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ React + Vite front end and a FastAPI backend.
 - Select database connections for new conversations via a popover
 - Connection form allows toggling between a full database URL or separate host credentials, disabling unused credential inputs while keeping the database name editable
 - Create conversations and retrieve full message history
+- Conversation titles are automatically suggested by a `title_generator` LLM agent based on the first user prompt
 - Toggleable sidebar built with a shadcn UI component for switching conversations and configuring connections, fetching conversations on mount
 - Optional mock user, conversation, and message data for frontend development
 - Global dark theme toggle via sun/moon icon button on all pages
@@ -133,7 +134,9 @@ JWT cookie unless noted.
 - `GET /conversations` – list conversations for the current user. Returns an array
   of objects with each conversation's `id` and optional `title`.
 - `GET /conversations/{id}` – fetch a conversation with its messages
-- `POST /conversations` – create a conversation bound to a DB connection
+- `POST /conversations` – create a conversation bound to a DB connection. Clients
+  provide a UUID and first prompt; if the ID is new, the response also includes
+  a generated title.
 - `POST /conversations/start` – initiate a workflow run and receive an SSE URL
 - `POST /conversations/{id}/query` – send a prompt and run the AI workflow. The
   response uses a standard envelope with `status`, `code`, and a `data.message`

--- a/client/src/hooks/useMessages.ts
+++ b/client/src/hooks/useMessages.ts
@@ -72,14 +72,18 @@ export function useMessages({
     try {
       if (!convoId) {
         if (!selectedConn) return
-        const { conversation_id } = await createConversation({
+        const newId = crypto.randomUUID()
+        const { conversation_id, title } = await createConversation({
           user_id: user.user_id,
           db_connection_id: selectedConn,
-          title: trimmed.slice(0, 20),
+          conversation_id: newId,
+          prompt: trimmed,
         })
         convoId = conversation_id
         setCurrentConvo(convoId)
-        setConvos((prev) => [{ id: convoId!, title: trimmed.slice(0, 20) }, ...prev])
+        if (title) {
+          setConvos((prev) => [{ id: convoId!, title }, ...prev])
+        }
       }
       const id = crypto.randomUUID()
       loadingId = crypto.randomUUID()

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -212,13 +212,22 @@ export async function getConversation(id: string) {
   })
 }
 
-export async function createConversation(body: { user_id: string; db_connection_id: string; title?: string; model?: string }) {
-  return fetchJson<{ conversation_id: string }>(`${API_BASE}/conversations`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    credentials: 'include',
-  })
+export async function createConversation(body: {
+  user_id: string
+  db_connection_id: string
+  conversation_id: string
+  prompt: string
+  model?: string
+}) {
+  return fetchJson<{ conversation_id: string; title?: string }>(
+    `${API_BASE}/conversations`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      credentials: 'include',
+    }
+  )
 }
 
 export async function conversationQuery(

--- a/server/api/v1/routes/conversations.py
+++ b/server/api/v1/routes/conversations.py
@@ -36,10 +36,16 @@ async def create_conversation(
 ) -> ConversationCreateResponse:
     if token_data["user_id"] != request.user_id:
         raise HTTPException(status_code=403, detail="Forbidden")
-    conv_id = await conversation_service.create_conversation(
-        request.user_id, request.db_connection_id, request.title, request.model
+    conv_id, title = await conversation_service.create_conversation(
+        request.conversation_id,
+        request.user_id,
+        request.db_connection_id,
+        request.prompt,
+        request.model,
     )
-    return ConversationCreateResponse(conversation_id=conv_id)
+    if title is None:
+        return ConversationCreateResponse(conversation_id=conv_id)
+    return ConversationCreateResponse(conversation_id=conv_id, title=title)
 
 
 @router.post("/start", status_code=status.HTTP_200_OK)

--- a/server/schemas/conversation.py
+++ b/server/schemas/conversation.py
@@ -77,14 +77,16 @@ class ConversationCreateRequest(BaseModel):
 
     user_id: str
     db_connection_id: str
-    title: Optional[str] = None
+    conversation_id: str
+    prompt: str
     model: Optional[str] = None
 
 
 class ConversationCreateResponse(BaseModel):
-    """Response containing the new conversation id."""
+    """Response containing the conversation id and an optional title."""
 
     conversation_id: str
+    title: Optional[str] = None
 
 
 class ConversationListItem(BaseModel):

--- a/server/services/conversation_service.py
+++ b/server/services/conversation_service.py
@@ -6,28 +6,41 @@ from typing import Any, Dict, Optional, Tuple, List
 from db.database import get_pool
 from schemas.db_connection import DBConnection
 from .semantic_mapping_service import ensure_mapping
+from .llm_service import generate_title
 
 
 logger = logging.getLogger(__name__)
 
 
 async def create_conversation(
-    user_id: str, db_connection_id: str, title: Optional[str], model: Optional[str]
-) -> str:
-    """Create a new conversation and return its id."""
+    conversation_id: str,
+    user_id: str,
+    db_connection_id: str,
+    prompt: str,
+    model: Optional[str],
+) -> Tuple[str, Optional[str]]:
+    """Create a new conversation and return its id and optional title."""
     pool = await get_pool()
     async with pool.acquire() as conn:
-        row = await conn.fetchrow(
+        existing = await conn.fetchrow(
+            "SELECT 1 FROM conversation WHERE id=$1",
+            conversation_id,
+        )
+        if existing:
+            return conversation_id, None
+
+        title = await generate_title(prompt, model)
+        await conn.execute(
             """
-            INSERT INTO conversation (user_id, db_connection_id, title, model)
-            VALUES ($1, $2, $3, $4) RETURNING id
+            INSERT INTO conversation (id, user_id, db_connection_id, title, model)
+            VALUES ($1, $2, $3, $4, $5)
             """,
+            conversation_id,
             user_id,
             db_connection_id,
             title,
             model,
         )
-        convo_id = str(row["id"])
 
         db_row = await conn.fetchrow(
             """
@@ -45,7 +58,7 @@ async def create_conversation(
             f"@{db_row['host']}:{db_row['port']}/{db_row['db_name']}"
         )
         await ensure_mapping(user_id, db_connection_id, dsn)
-    return convo_id
+    return conversation_id, title
 
 
 async def get_conversation_db_connection(

--- a/server/services/llm_service.py
+++ b/server/services/llm_service.py
@@ -121,3 +121,37 @@ async def choose_charts(
         return list(selections)
 
     return await asyncio.to_thread(_run)
+
+
+async def generate_title(prompt: str, model_name: str | None = None) -> str:
+    """Generate a short conversation title from the user's prompt."""
+
+    def _run() -> str:
+        client = OpenAI(api_key=settings.LLM_API_KEY)
+        model = model_name or settings.LLM_RESPONSE_MODEL
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "conversation_title",
+                "schema": {
+                    "type": "object",
+                    "properties": {"response": {"type": "string"}},
+                    "required": ["response"],
+                },
+            },
+        }
+        message = (
+            "Generate a concise title using between 2 and 7 words for the "
+            f"following user message.\nUser message: {prompt}"
+        )
+        resp, raw = create_logged_response(
+            client,
+            step="title_generator",
+            model=model,
+            input=message,
+            response_format=response_format,
+        )
+        title = LLMResponse.model_validate_json(raw).response
+        return str(title).strip()
+
+    return await asyncio.to_thread(_run)


### PR DESCRIPTION
## Summary
- return generated conversation title only when the conversation ID is new
- let the frontend skip updating the sidebar when no title comes back
- document optional title in conversation creation API

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c403a6e388832396219cacb700dadd